### PR TITLE
Rename metrics and refactor configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,22 +17,19 @@ $ docker run -p 9531:9531 --env ARTI_PASSWORD=$ARTI_ADMIN_PASS peimanja/artifact
 
 ```bash
 $  Docker run peimanja/artifactory_exporter:latest -h
-usage: artifactory_exporter --artifactory.user=ARTIFACTORY.USER --artifactory.password=ARTIFACTORY.PASSWORD [<flags>]
+usage: main --artifactory.user=ARTIFACTORY.USER [<flags>]
 
 Flags:
-  -h, --help            Show context-sensitive help (also try --help-long and
-                        --help-man).
-      --web.listen-address=":9531"
+  -h, --help            Show context-sensitive help (also try --help-long and --help-man).
+      --web.listen-address=":9531"  
                         Address to listen on for web interface and telemetry.
-      --web.telemetry-path="/metrics"
+      --web.telemetry-path="/metrics"  
                         Path under which to expose metrics.
-      --artifactory.user=ARTIFACTORY.USER
+      --artifactory.user=ARTIFACTORY.USER  
                         User to access Artifactory.
-      --artifactory.password=ARTIFACTORY.PASSWORD
-                        Password of the user accessing the Artifactory.
-      --artifactory.scrape-uri="http://localhost:8081/artifactory"
+      --artifactory.scrape-uri="http://localhost:8081/artifactory"  
                         URI on which to scrape Artifactory.
-      --artifactory.scrape-interval=30
+      --artifactory.scrape-interval=30  
                         How often to scrape Artifactory in secoonds.
       --exporter.debug  Enable debug mode.
 ```
@@ -42,10 +39,10 @@ Flags:
 | `web.listen-address`<br />`WEB_LISTEN_ADDR` | No | `:9531`| Address to listen on for web interface and telemetry |
 | `web.telemetry-path`<br />`WEB_TELEMETRY_PATH` | No | `/metrics` | Path under which to expose Prometheus metrics |
 | `artifactory.user`<br />`ARTI_USER` | Yes | | User to access Artifactory |
-| `artifactory.password`<br />`ARTI_PASSWORD` | Yes | | Password of the user accessing the Artifactory |
 | `artifactory.scrape-uri`<br />`ARTI_SCRAPE_URI` | No | `http://localhost:8081/artifactory` | JFrog Artifactory URL |
 | `artifactory.scrape-interval`<br />`ARTI_SCRAPE_INTERVAL` | No | | JFrog Artifactory URL |
 | `exporter.debug`<br />`DEBUG` | No | `false` | Enable debug mode |
+| `ARTI_PASSWORD` | Yes | | Password of the user accessing the Artifactory |
 
 ### Metrics
 
@@ -53,17 +50,17 @@ The exporter returns the following metrics:
 
 | Metric | Description | Labels |
 | ------ | ----------- | ------ |
-| arti_up | Current health status of the server 1 = UP |  |
-| arti_security_users | Number of artifactory users | `realm` |
-| arti_artifacts_total_count | Total artifacts count stored in Artifactory |  |
-| arti_artifacts_total_size_bytes | Total artifacts Size stored in Artifactory in bytes |  |
-| arti_binaries_total_count | Total binaries count stored in Artifactory |  |
-| arti_binaries_total_size_bytes | Total binaries Size stored in Artifactory in bytes |  |
-| arti_filestore_bytes | Total space in the file store in bytes | `storage_dir`, `storage_type` |
-| arti_filestore_used_bytes | Space used in the file store in bytes | `storage_dir`, `storage_type` |
-| arti_filestore_free_bytes | Space free in the file store in bytes | `storage_dir`, `storage_type` |
-| arti_repo_used_bytes | Space used by an Artifactory repository in bytes | `name`, `package_type`, `type` |
-| arti_repo_folder_count | Number of folders in an Artifactory repository | `name`, `package_type`, `type` |
-| arti_repo_files_count | Number files in an Artifactory repository | `name`, `package_type`, `type` |
-| arti_repo_items_count | Number Items in an Artifactory repository | `name`, `package_type`, `type` |
-| arti_repo_percentage | Percentage of space used by an Artifactory repository | `name`, `package_type`, `type` |
+| artifactory_up | Current health status of the server 1 = UP |  |
+| artifactory_security_users | Number of artifactory users | `realm` |
+| artifactory_artifacts_total_count | Total artifacts count stored in Artifactory |  |
+| artifactory_artifacts_total_size_bytes | Total artifacts Size stored in Artifactory in bytes |  |
+| artifactory_binaries_total_count | Total binaries count stored in Artifactory |  |
+| artifactory_binaries_total_size_bytes | Total binaries Size stored in Artifactory in bytes |  |
+| artifactory_filestore_bytes | Total space in the file store in bytes | `storage_dir`, `storage_type` |
+| artifactory_filestore_used_bytes | Space used in the file store in bytes | `storage_dir`, `storage_type` |
+| artifactory_filestore_free_bytes | Space free in the file store in bytes | `storage_dir`, `storage_type` |
+| artifactory_repo_used_bytes | Space used by an Artifactory repository in bytes | `name`, `package_type`, `type` |
+| artifactory_repo_folder_count | Number of folders in an Artifactory repository | `name`, `package_type`, `type` |
+| artifactory_repo_files_count | Number files in an Artifactory repository | `name`, `package_type`, `type` |
+| artifactory_repo_items_count | Number Items in an Artifactory repository | `name`, `package_type`, `type` |
+| artifactory_repo_percentage | Percentage of space used by an Artifactory repository | `name`, `package_type`, `type` |

--- a/arti/api_client.go
+++ b/arti/api_client.go
@@ -4,19 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"io/ioutil"
-	"net"
 	"net/http"
-	"net/url"
 	"strconv"
 
 	log "github.com/sirupsen/logrus"
 )
-
-type APIClientConfig struct {
-	Url  string
-	User string
-	Pass string
-}
 
 type SearchFeilds struct {
 	Action string
@@ -82,16 +74,6 @@ func QueryArtiApi(config *APIClientConfig, path string) ([]byte, error) {
 		"method": "GET",
 		"uri":    config.Url + "/api/" + path,
 	}).Debugln("Making API request")
-
-	u, err := url.Parse(config.Url)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	_, err = net.LookupHost(u.Hostname())
-	if err != nil {
-		log.Fatal(err)
-	}
 
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", config.Url+"/api/"+path, nil)

--- a/arti/config.go
+++ b/arti/config.go
@@ -1,0 +1,69 @@
+package arti
+
+import (
+	"net"
+	"net/url"
+
+	"github.com/kelseyhightower/envconfig"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	listenAddress      = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Envar("WEB_LISTEN_ADDR").Default(":9531").String()
+	metricsPath        = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Envar("WEB_TELEMETRY_PATH").Default("/metrics").String()
+	artiUser           = kingpin.Flag("artifactory.user", "User to access Artifactory.").Required().Envar("ARTI_USER").String()
+	artiScrapeURI      = kingpin.Flag("artifactory.scrape-uri", "URI on which to scrape Artifactory.").Envar("ARTI_SCRAPE_URI").Default("http://localhost:8081/artifactory").String()
+	artiScrapeInterval = kingpin.Flag("artifactory.scrape-interval", "How often to scrape Artifactory in secoonds.").Envar("ARTI_SCRAPE_INTERVAL").Default("30").Int64()
+	debug              = kingpin.Flag("exporter.debug", "Enable debug mode.").Envar("DEBUG").Default("false").Bool()
+)
+
+type APIClientConfig struct {
+	Url  string
+	User string
+	Pass string `required:"true" envconfig:"ARTI_PASSWORD"`
+}
+
+type Config struct {
+	ListenAddress      string
+	MetricsPath        string
+	ArtiScrapeInterval int64
+	Debug              bool
+	ApiConfig          *APIClientConfig
+}
+
+func NewConfig() (*Config, error) {
+
+	kingpin.HelpFlag.Short('h')
+	kingpin.Parse()
+
+	var apiConfig APIClientConfig
+	err := envconfig.Process("", &apiConfig)
+	if err != nil {
+		log.Debugln(err)
+		return &Config{}, err
+	}
+
+	u, err := url.Parse(*artiScrapeURI)
+	if err != nil {
+		log.Debugln(err)
+		return &Config{}, err
+	}
+	_, err = net.LookupHost(u.Hostname())
+	if err != nil {
+		log.Debugln(err)
+		return &Config{}, err
+	}
+
+	apiConfig.Url = *artiScrapeURI
+	apiConfig.User = *artiUser
+
+	return &Config{
+		*listenAddress,
+		*metricsPath,
+		*artiScrapeInterval,
+		*debug,
+		&apiConfig,
+	}, nil
+
+}

--- a/arti/metrics.go
+++ b/arti/metrics.go
@@ -4,7 +4,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const namespace = "arti"
+const namespace = "artifactory"
 
 var (
 	Up = prometheus.NewGauge(
@@ -26,25 +26,25 @@ var (
 	ArtifactCountTotal = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
-			Name:      "artifacts_total_count",
+			Name:      "artifacts",
 			Help:      "Total artifacts count stored in Artifactory",
 		})
 	ArtifactsSizeTotal = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
-			Name:      "artifacts_total_size_bytes",
+			Name:      "artifacts_size_bytes",
 			Help:      "Total artifacts Size stored in Artifactory in bytes",
 		})
 	BinariesCountTotal = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
-			Name:      "binaries_total_count",
+			Name:      "binaries",
 			Help:      "Total binaries count stored in Artifactory",
 		})
 	BinariesSizeTotal = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
-			Name:      "binaries_total_size_bytes",
+			Name:      "binaries_size_bytes",
 			Help:      "Total binaries Size stored in Artifactory in bytes",
 		})
 	FileStore = prometheus.NewGaugeVec(

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/peimanja/artifactory_exporter
 go 1.12
 
 require (
+	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/prometheus/client_golang v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -27,6 +28,8 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
@@ -38,6 +41,7 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
@@ -60,6 +64,7 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
- Rename the metrics namespace from `arti` to `artifactory`
- Remove the `--artifactory.password` flag. Now it only supports passing the artifactory password via `ARTI_PASSWORD` environment variable.
- Refactor the configs and add some validation