### PR TITLE
Add replication status metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The exporter returns the following metrics:
 | artifactory_up | Was the last scrape of Artifactory successful. |  |
 | artifactory_exporter_total_scrapes | Current total artifactory scrapes. |  |
 | artifactory_exporter_json_parse_failures |Number of errors while parsing Json. |  |
+| artifactory_replication_enabled | Replication status for an Artifactory repository (1 = enabled). | `name`, `type`, `cron_exp` |
 | artifactory_security_users | Number of Artifactory users for each realm. | `realm` |
 | artifactory_storage_artifacts | Total artifacts count stored in Artifactory. |  |
 | artifactory_storage_artifacts_size_bytes | Total artifacts Size stored in Artifactory in bytes. |  |

--- a/collector/replication.go
+++ b/collector/replication.go
@@ -1,0 +1,56 @@
+package collector
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type replication struct {
+	ReplicationType                 string `json:"replicationType"`
+	Enabled                         bool   `json:"enabled"`
+	CronExp                         string `json:"cronExp"`
+	SyncDeletes                     bool   `json:"syncDeletes"`
+	SyncProperties                  bool   `json:"syncProperties"`
+	PathPrefix                      string `json:"pathPrefix"`
+	RepoKey                         string `json:"repoKey"`
+	EnableEventReplication          bool   `json:"enableEventReplication"`
+	CheckBinaryExistenceInFilestore bool   `json:"checkBinaryExistenceInFilestore"`
+	SyncStatistics                  bool   `json:"syncStatistics"`
+}
+
+func (e *Exporter) fetchReplications() ([]replication, error) {
+	var replications []replication
+	resp, err := fetchHTTP(e.URI, "replications", e.bc, e.sslVerify, e.timeout)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(resp, &replications); err != nil {
+		e.jsonParseFailures.Inc()
+		return replications, err
+	}
+	return replications, nil
+}
+
+func (e *Exporter) exportReplications(replications []replication, ch chan<- prometheus.Metric) {
+	if len(replications) == 0 {
+		return
+	}
+	for _, replication := range replications {
+		for metricName, metric := range replicationMetrics {
+			switch metricName {
+			case "enabled":
+				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, b2f(replication.Enabled), replication.RepoKey, strings.ToLower(replication.ReplicationType), replication.CronExp)
+
+			}
+		}
+	}
+}
+
+func b2f(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}


### PR DESCRIPTION
The `api/replications` returns list of configured replications.

```
[ {
  "replicationType" : "PUSH",
  "enabled" : true,
  "cronExp" : "0 0 12 * * ?",
  "syncDeletes" : false,
  "syncProperties" : true,
  "repoKey" : "local-repo",
  "enableEventReplication" : false,
  "checkBinaryExistenceInFilestore" : false,
  "url" : "http://artifactory.ca/test-local-repo",
  "syncStatistics" : false
}, {
  "replicationType" : "PULL",
  "enabled" : true,
  "cronExp" : "0 0 12 * * ?",
  "syncDeletes" : false,
  "syncProperties" : false,
  "repoKey" : "global-dockerhub",
  "enableEventReplication" : false,
  "checkBinaryExistenceInFilestore" : false,
  "syncStatistics" : false
}]
```

Adding `artifactory_replication_enabled` gauge metric that has `name`, `type`, `cron_exp` labels. Value of `1` means replication is  enabled and 0 means it is disabled.
