### PR TITLE
Lenient matching to allow single digit dates

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -208,7 +208,7 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) (up float64) {
 		case "license":
 			var validThrough float64
 			timeNow := float64(time.Now().Unix())
-			if validThroughTime, err := time.Parse("Jan 02, 2006", license.ValidThrough); err != nil {
+			if validThroughTime, err := time.Parse("Jan 2, 2006", license.ValidThrough); err != nil {
 				level.Warn(e.logger).Log("msg", "Can't parse Artifactory license ValidThrough", "err", err)
 				validThrough = timeNow
 			} else {


### PR DESCRIPTION
Just checked, license details are coming incorrect when the expiry is Apr 7,2020
Changing format to allow these dates also.
Thanks!