### PR TITLE
Storage parsing updates to support Artifactory 7.x.x

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -229,24 +229,24 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) (up float64) {
 		level.Error(e.logger).Log("msg", "Can't scrape Artifactory when fetching storageinfo", "err", err)
 		return 0
 	}
-	fileStoreType := strings.ToLower(storageInfo.StorageSummary.FileStoreSummary.StorageType)
-	fileStoreDir := storageInfo.StorageSummary.FileStoreSummary.StorageDirectory
+	fileStoreType := strings.ToLower(storageInfo.FileStoreSummary.StorageType)
+	fileStoreDir := storageInfo.FileStoreSummary.StorageDirectory
 	for metricName, metric := range storageMetrics {
 		switch metricName {
 		case "artifacts":
-			e.exportCount(metricName, metric, storageInfo.StorageSummary.BinariesSummary.ArtifactsCount, ch)
+			e.exportCount(metricName, metric, storageInfo.BinariesSummary.ArtifactsCount, ch)
 		case "artifactsSize":
-			e.exportSize(metricName, metric, storageInfo.StorageSummary.BinariesSummary.ArtifactsSize, ch)
+			e.exportSize(metricName, metric, storageInfo.BinariesSummary.ArtifactsSize, ch)
 		case "binaries":
-			e.exportCount(metricName, metric, storageInfo.StorageSummary.BinariesSummary.BinariesCount, ch)
+			e.exportCount(metricName, metric, storageInfo.BinariesSummary.BinariesCount, ch)
 		case "binariesSize":
-			e.exportSize(metricName, metric, storageInfo.StorageSummary.BinariesSummary.BinariesSize, ch)
+			e.exportSize(metricName, metric, storageInfo.BinariesSummary.BinariesSize, ch)
 		case "filestore":
-			e.exportFilestore(metricName, metric, storageInfo.StorageSummary.FileStoreSummary.TotalSpace, fileStoreType, fileStoreDir, ch)
+			e.exportFilestore(metricName, metric, storageInfo.FileStoreSummary.TotalSpace, fileStoreType, fileStoreDir, ch)
 		case "filestoreUsed":
-			e.exportFilestore(metricName, metric, storageInfo.StorageSummary.FileStoreSummary.UsedSpace, fileStoreType, fileStoreDir, ch)
+			e.exportFilestore(metricName, metric, storageInfo.FileStoreSummary.UsedSpace, fileStoreType, fileStoreDir, ch)
 		case "filestoreFree":
-			e.exportFilestore(metricName, metric, storageInfo.StorageSummary.FileStoreSummary.FreeSpace, fileStoreType, fileStoreDir, ch)
+			e.exportFilestore(metricName, metric, storageInfo.FileStoreSummary.FreeSpace, fileStoreType, fileStoreDir, ch)
 		}
 	}
 	e.extractRepoSummary(storageInfo, ch)

--- a/collector/storage.go
+++ b/collector/storage.go
@@ -12,33 +12,14 @@ import (
 )
 
 type storageInfo struct {
-	StorageSummary struct {
-		BinariesSummary struct {
-			BinariesCount  string `json:"binariesCount"`
-			BinariesSize   string `json:"binariesSize"`
-			ArtifactsSize  string `json:"artifactsSize"`
-			Optimization   string `json:"optimization"`
-			ItemsCount     string `json:"itemsCount"`
-			ArtifactsCount string `json:"artifactsCount"`
-		} `json:"binariesSummary"`
-		FileStoreSummary struct {
-			StorageType      string `json:"storageType"`
-			StorageDirectory string `json:"storageDirectory"`
-			TotalSpace       string `json:"totalSpace"`
-			UsedSpace        string `json:"usedSpace"`
-			FreeSpace        string `json:"freeSpace"`
-		} `json:"fileStoreSummary"`
-		RepositoriesSummaryList []struct {
-			RepoKey      string `json:"repoKey"`
-			RepoType     string `json:"repoType"`
-			FoldersCount int    `json:"foldersCount"`
-			FilesCount   int    `json:"filesCount"`
-			UsedSpace    string `json:"usedSpace"`
-			ItemsCount   int    `json:"itemsCount"`
-			PackageType  string `json:"packageType"`
-			Percentage   string `json:"percentage"`
-		} `json:"repositoriesSummaryList"`
-	} `json:"storageSummary"`
+	BinariesSummary struct {
+		BinariesCount  string `json:"binariesCount"`
+		BinariesSize   string `json:"binariesSize"`
+		ArtifactsSize  string `json:"artifactsSize"`
+		Optimization   string `json:"optimization"`
+		ItemsCount     string `json:""`
+		ArtifactsCount string `json:"artifactsCount"`
+	} `json:"binariesSummary"`
 	FileStoreSummary struct {
 		StorageType      string `json:"storageType"`
 		StorageDirectory string `json:"storageDirectory"`
@@ -56,14 +37,6 @@ type storageInfo struct {
 		PackageType  string `json:"packageType"`
 		Percentage   string `json:"percentage"`
 	} `json:"repositoriesSummaryList"`
-	BinariesSummary struct {
-		BinariesCount  string `json:"binariesCount"`
-		BinariesSize   string `json:"binariesSize"`
-		ArtifactsSize  string `json:"artifactsSize"`
-		Optimization   string `json:"optimization"`
-		ItemsCount     string `json:""`
-		ArtifactsCount string `json:"artifactsCount"`
-	} `json:"binariesSummary"`
 }
 
 func (e *Exporter) fetchStorageInfo() (storageInfo, error) {
@@ -185,7 +158,7 @@ func (e *Exporter) extractRepoSummary(storageInfo storageInfo, ch chan<- prometh
 	rs := repoSummary{}
 	repoSummaryList := []repoSummary{}
 	level.Debug(e.logger).Log("msg", "Extracting repo summeriest")
-	for _, repo := range storageInfo.StorageSummary.RepositoriesSummaryList {
+	for _, repo := range storageInfo.RepositoriesSummaryList {
 		if repo.RepoKey == "TOTAL" {
 			continue
 		}


### PR DESCRIPTION
* Removed references to duplicated `storageSummary` key (removed in 7.x)
  * All values from `storageSummary.*` keys are present in top level json keys
  * Validated update against `5.11.7`, `6.9.3`, `6.13.0`, 6.14.0`, `6.18.1`, `7.2.1`, and `7.3.2`
* Added edge-case handling for `repo.Percentage` where value = `N/A` on new deployments
* Added debug logging for `UsedSpace`/`Percentage` parsing errors