### PR TITLE
Updates to allow multiple replication targets per-repo

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -22,7 +22,7 @@ const (
 var (
 	filestoreLabelNames   = []string{"storage_type", "storage_dir"}
 	repoLabelNames        = []string{"name", "type", "package_type"}
-	replicationLabelNames = []string{"name", "type", "cron_exp"}
+	replicationLabelNames = []string{"name", "type", "url", "cron_exp"}
 )
 
 func newMetric(metricName string, subsystem string, docString string, labelNames []string) *prometheus.Desc {

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -252,7 +252,7 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) (up float64) {
 	e.extractRepoSummary(storageInfo, ch)
 
 	// Some API endpoints are not available in OSS
-	if licenseType != "oss" && licenseType != "trial" {
+	if licenseType != "oss" {
 		// Fetch Security stats
 		users, err := e.fetchUsers()
 		if err != nil {

--- a/collector/replication.go
+++ b/collector/replication.go
@@ -16,6 +16,7 @@ type replication struct {
 	SyncProperties                  bool   `json:"syncProperties"`
 	PathPrefix                      string `json:"pathPrefix"`
 	RepoKey                         string `json:"repoKey"`
+	URL                             string `json:"url"`
 	EnableEventReplication          bool   `json:"enableEventReplication"`
 	CheckBinaryExistenceInFilestore bool   `json:"checkBinaryExistenceInFilestore"`
 	SyncStatistics                  bool   `json:"syncStatistics"`
@@ -48,9 +49,10 @@ func (e *Exporter) exportReplications(replications []replication, ch chan<- prom
 				enabled := b2f(replication.Enabled)
 				repo := replication.RepoKey
 				rType := strings.ToLower(replication.ReplicationType)
+				rURL := strings.ToLower(replication.URL)
 				cronExp := replication.CronExp
-				level.Debug(e.logger).Log("msg", "Registering metric", "metric", metricName, "repo", replication.RepoKey, "type", rType, "cron", cronExp, "value", enabled)
-				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, enabled, repo, rType, cronExp)
+				level.Debug(e.logger).Log("msg", "Registering metric", "metric", metricName, "repo", replication.RepoKey, "type", rType, "url", rURL, "cron", cronExp, "value", enabled)
+				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, enabled, repo, rType, rURL, cronExp)
 			}
 		}
 	}


### PR DESCRIPTION
* Updated `licenseType != "oss"` check to continue when `licenseType == 'trial'`
* Added `URL` to `replication` struct and metrics allowing for multiple replications on a single local repo
  * Will still error if there are 2 replications to the same URL, but will allow push+pull or multi-push from single local repo to different URLs
* Validated update against `5.11.7`, `6.9.3`, `6.13.0`, `6.14.0`, `6.18.1`, `7.2.1`, and `7.3.2`
