### PR TITLE
feat: add node_id label to all exported metrics

### DIFF
--- a/artifactory/replication.go
+++ b/artifactory/replication.go
@@ -22,19 +22,25 @@ type Replication struct {
 	CheckBinaryExistenceInFilestore bool   `json:"checkBinaryExistenceInFilestore"`
 	SyncStatistics                  bool   `json:"syncStatistics"`
 }
+type Replications struct {
+	Replications []Replication
+	NodeId       string
+}
 
 // FetchReplications makes the API call to replication endpoint and returns []Replication
-func (c *Client) FetchReplications() ([]Replication, error) {
-	var replications []Replication
+func (c *Client) FetchReplications() (Replications, error) {
+	var replications Replications
 	level.Debug(c.logger).Log("msg", "Fetching replications stats")
 	resp, err := c.FetchHTTP(replicationEndpoint)
 	if err != nil {
 		if err.(*APIError).status == 404 {
 			return replications, nil
 		}
-		return nil, err
+		return replications, err
 	}
-	if err := json.Unmarshal(resp, &replications); err != nil {
+	replications.NodeId = resp.NodeId
+
+	if err := json.Unmarshal(resp.Body, &replications.Replications); err != nil {
 		level.Error(c.logger).Log("msg", "There was an issue when try to unmarshal replication respond")
 		return replications, &UnmarshalError{
 			message:  err.Error(),

--- a/artifactory/security.go
+++ b/artifactory/security.go
@@ -16,16 +16,21 @@ type User struct {
 	Name  string `json:"name"`
 	Realm string `json:"realm"`
 }
+type Users struct {
+	Users  []User
+	NodeId string
+}
 
 // FetchUsers makes the API call to users endpoint and returns []User
-func (c *Client) FetchUsers() ([]User, error) {
-	var users []User
+func (c *Client) FetchUsers() (Users, error) {
+	var users Users
 	level.Debug(c.logger).Log("msg", "Fetching users stats")
 	resp, err := c.FetchHTTP(usersEndpoint)
 	if err != nil {
-		return nil, err
+		return users, err
 	}
-	if err := json.Unmarshal(resp, &users); err != nil {
+	users.NodeId = resp.NodeId
+	if err := json.Unmarshal(resp.Body, &users.Users); err != nil {
 		level.Error(c.logger).Log("msg", "There was an issue when try to unmarshal users respond")
 		return users, &UnmarshalError{
 			message:  err.Error(),
@@ -40,16 +45,21 @@ type Group struct {
 	Name  string `json:"name"`
 	Realm string `json:"uri"`
 }
+type Groups struct {
+	Groups []Group
+	NodeId string
+}
 
 // FetchGroups makes the API call to groups endpoint and returns []Group
-func (c *Client) FetchGroups() ([]Group, error) {
-	var groups []Group
+func (c *Client) FetchGroups() (Groups, error) {
+	var groups Groups
 	level.Debug(c.logger).Log("msg", "Fetching groups stats")
 	resp, err := c.FetchHTTP(groupsEndpoint)
 	if err != nil {
 		return groups, err
 	}
-	if err := json.Unmarshal(resp, &groups); err != nil {
+	groups.NodeId = resp.NodeId
+	if err := json.Unmarshal(resp.Body, &groups.Groups); err != nil {
 		level.Error(c.logger).Log("msg", "There was an issue when try to unmarshal groups respond")
 		return groups, &UnmarshalError{
 			message:  err.Error(),

--- a/artifactory/storageinfo.go
+++ b/artifactory/storageinfo.go
@@ -37,6 +37,7 @@ type StorageInfo struct {
 		PackageType  string `json:"packageType"`
 		Percentage   string `json:"percentage"`
 	} `json:"repositoriesSummaryList"`
+	NodeId string
 }
 
 // FetchStorageInfo makes the API call to storageinfo endpoint and returns StorageInfo
@@ -47,7 +48,8 @@ func (c *Client) FetchStorageInfo() (StorageInfo, error) {
 	if err != nil {
 		return storageInfo, err
 	}
-	if err := json.Unmarshal(resp, &storageInfo); err != nil {
+	storageInfo.NodeId = resp.NodeId
+	if err := json.Unmarshal(resp.Body, &storageInfo); err != nil {
 		level.Error(c.logger).Log("msg", "There was an issue when try to unmarshal storageInfo respond")
 		return storageInfo, &UnmarshalError{
 			message:  err.Error(),

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -12,9 +12,10 @@ const (
 )
 
 var (
-	filestoreLabelNames   = []string{"storage_type", "storage_dir"}
-	repoLabelNames        = []string{"name", "type", "package_type"}
-	replicationLabelNames = []string{"name", "type", "url", "cron_exp"}
+	defaultLabelNames     = []string{"node_id"}
+	filestoreLabelNames   = append([]string{"storage_type", "storage_dir"}, defaultLabelNames...)
+	repoLabelNames        = append([]string{"name", "type", "package_type"}, defaultLabelNames...)
+	replicationLabelNames = append([]string{"name", "type", "url", "cron_exp"}, defaultLabelNames...)
 )
 
 func newMetric(metricName string, subsystem string, docString string, labelNames []string) *prometheus.Desc {
@@ -29,15 +30,15 @@ var (
 	}
 
 	securityMetrics = metrics{
-		"users":  newMetric("users", "security", "Number of Artifactory users for each realm.", []string{"realm"}),
-		"groups": newMetric("groups", "security", "Number of Artifactory groups", nil),
+		"users":  newMetric("users", "security", "Number of Artifactory users for each realm.", append([]string{"realm"}, defaultLabelNames...)),
+		"groups": newMetric("groups", "security", "Number of Artifactory groups", defaultLabelNames),
 	}
 
 	storageMetrics = metrics{
-		"artifacts":      newMetric("artifacts", "storage", "Total artifacts count stored in Artifactory.", nil),
-		"artifactsSize":  newMetric("artifacts_size_bytes", "storage", "Total artifacts Size stored in Artifactory in bytes.", nil),
-		"binaries":       newMetric("binaries", "storage", "Total binaries count stored in Artifactory.", nil),
-		"binariesSize":   newMetric("binaries_size_bytes", "storage", "Total binaries Size stored in Artifactory in bytes.", nil),
+		"artifacts":      newMetric("artifacts", "storage", "Total artifacts count stored in Artifactory.", defaultLabelNames),
+		"artifactsSize":  newMetric("artifacts_size_bytes", "storage", "Total artifacts Size stored in Artifactory in bytes.", defaultLabelNames),
+		"binaries":       newMetric("binaries", "storage", "Total binaries count stored in Artifactory.", defaultLabelNames),
+		"binariesSize":   newMetric("binaries_size_bytes", "storage", "Total binaries Size stored in Artifactory in bytes.", defaultLabelNames),
 		"filestore":      newMetric("filestore_bytes", "storage", "Total available space in the file store in bytes.", filestoreLabelNames),
 		"filestoreUsed":  newMetric("filestore_used_bytes", "storage", "Used space in the file store in bytes.", filestoreLabelNames),
 		"filestoreFree":  newMetric("filestore_free_bytes", "storage", "Free space in the file store in bytes.", filestoreLabelNames),
@@ -49,9 +50,9 @@ var (
 	}
 
 	systemMetrics = metrics{
-		"healthy": newMetric("healthy", "system", "Is Artifactory working properly (1 = healthy).", nil),
-		"version": newMetric("version", "system", "Version and revision of Artifactory as labels.", []string{"version", "revision"}),
-		"license": newMetric("license", "system", "License type and expiry as labels, seconds to expiration as value", []string{"type", "licensed_to", "expires"}),
+		"healthy": newMetric("healthy", "system", "Is Artifactory working properly (1 = healthy).", defaultLabelNames),
+		"version": newMetric("version", "system", "Version and revision of Artifactory as labels.", append([]string{"version", "revision"}, defaultLabelNames...)),
+		"license": newMetric("license", "system", "License type and expiry as labels, seconds to expiration as value", append([]string{"type", "licensed_to", "expires"}, defaultLabelNames...)),
 	}
 
 	artifactsMetrics = metrics{

--- a/collector/replication.go
+++ b/collector/replication.go
@@ -15,11 +15,11 @@ func (e *Exporter) exportReplications(ch chan<- prometheus.Metric) error {
 		e.totalAPIErrors.Inc()
 		return err
 	}
-	if len(replications) == 0 {
+	if len(replications.Replications) == 0 {
 		level.Debug(e.logger).Log("msg", "No replications stats found")
 		return nil
 	}
-	for _, replication := range replications {
+	for _, replication := range replications.Replications {
 		for metricName, metric := range replicationMetrics {
 			switch metricName {
 			case "enabled":
@@ -29,7 +29,7 @@ func (e *Exporter) exportReplications(ch chan<- prometheus.Metric) error {
 				rURL := strings.ToLower(replication.URL)
 				cronExp := replication.CronExp
 				level.Debug(e.logger).Log("msg", "Registering metric", "metric", metricName, "repo", replication.RepoKey, "type", rType, "url", rURL, "cron", cronExp, "value", enabled)
-				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, enabled, repo, rType, rURL, cronExp)
+				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, enabled, repo, rType, rURL, cronExp, replications.NodeId)
 			}
 		}
 	}

--- a/collector/security.go
+++ b/collector/security.go
@@ -14,13 +14,13 @@ type user struct {
 }
 
 // map[<realm>] <count>
-type realmUserCounts map[string] float64
+type realmUserCounts map[string]float64
 
 func (e *Exporter) countUsersPerRealm(users []artifactory.User) realmUserCounts {
 	level.Debug(e.logger).Log("msg", "Counting users")
-	usersPerRealm := realmUserCounts {}
+	usersPerRealm := realmUserCounts{}
 	for _, user := range users {
-		usersPerRealm[user.Realm]++;
+		usersPerRealm[user.Realm]++
 	}
 	return usersPerRealm
 }
@@ -34,8 +34,7 @@ func (e *Exporter) exportUsersCount(metricName string, metric *prometheus.Desc, 
 		return err
 	}
 
-	usersPerRealm := e.countUsersPerRealm(users)
-
+	usersPerRealm := e.countUsersPerRealm(users.Users)
 	totalUserCount := 0
 	for _, count := range usersPerRealm {
 		totalUserCount += int(count)
@@ -48,7 +47,7 @@ func (e *Exporter) exportUsersCount(metricName string, metric *prometheus.Desc, 
 	}
 	for realm, count := range usersPerRealm {
 		level.Debug(e.logger).Log("msg", "Registering metric", "metric", metricName, "realm", realm, "value", count)
-		ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, count, realm)
+		ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, count, realm, users.NodeId)
 	}
 	return nil
 }
@@ -66,7 +65,8 @@ func (e *Exporter) exportGroups(metricName string, metric *prometheus.Desc, ch c
 		e.totalAPIErrors.Inc()
 		return err
 	}
-	level.Debug(e.logger).Log("msg", "Registering metric", "metric", metricName, "value", float64(len(groups)))
-	ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, float64(len(groups)))
+
+	level.Debug(e.logger).Log("msg", "Registering metric", "metric", metricName, "value", float64(len(groups.Groups)))
+	ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, float64(len(groups.Groups)), groups.NodeId)
 	return nil
 }

--- a/collector/storage.go
+++ b/collector/storage.go
@@ -104,6 +104,7 @@ func (e *Exporter) extractRepo(storageInfo artifactory.StorageInfo) ([]repoSumma
 				return repoSummaryList, err
 			}
 		}
+		rs.NodeId = storageInfo.NodeId
 		repoSummaryList = append(repoSummaryList, rs)
 	}
 	return repoSummaryList, err

--- a/collector/system.go
+++ b/collector/system.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (e *Exporter) exportSystem(license artifactory.LicenseInfo, ch chan<- prometheus.Metric) error {
-	healthy, err := e.client.FetchHealth()
+	health, err := e.client.FetchHealth()
 	if err != nil {
 		level.Error(e.logger).Log("msg", "Couldn't scrape Artifactory when fetching system/ping", "err", err)
 		e.totalAPIErrors.Inc()
@@ -27,9 +27,9 @@ func (e *Exporter) exportSystem(license artifactory.LicenseInfo, ch chan<- prome
 	for metricName, metric := range systemMetrics {
 		switch metricName {
 		case "healthy":
-			ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, b2f(healthy))
+			ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, b2f(health.Healthy), health.NodeId)
 		case "version":
-			ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, 1, buildInfo.Version, buildInfo.Revision)
+			ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, 1, buildInfo.Version, buildInfo.Revision, buildInfo.NodeId)
 		case "license":
 			var validThrough float64
 			timeNow := float64(time.Now().Unix())
@@ -44,7 +44,7 @@ func (e *Exporter) exportSystem(license artifactory.LicenseInfo, ch chan<- prome
 					validThrough = float64(validThroughTime.Unix())
 				}
 			}
-			ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, validThrough-timeNow, licenseType, license.LicensedTo, license.ValidThrough)
+			ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, validThrough-timeNow, licenseType, license.LicensedTo, license.ValidThrough, license.NodeId)
 		}
 	}
 	return nil


### PR DESCRIPTION
The  `x-artifactory-node-id` header is returned on all calls to the artifactory API. Associating this header with the API response allows us to determine which artifactory instance the metrics have been polled from which is useful for creating dashboards.