### PR TITLE
Add work with Artifactory Community Edition for C/C++

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -120,7 +120,7 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) (up float64) {
 	}
 	licenseType = strings.ToLower(license.Type)
 	// Some API endpoints are not available in OSS
-	if licenseType != "oss" && licenseType != "jcr edition" {
+	if licenseType != "oss" && licenseType != "jcr edition" && licenseType != "community edition for c/c++" {
 		for metricName, metric := range securityMetrics {
 			switch metricName {
 			case "users":

--- a/collector/system.go
+++ b/collector/system.go
@@ -34,7 +34,7 @@ func (e *Exporter) exportSystem(license artifactory.LicenseInfo, ch chan<- prome
 			var validThrough float64
 			timeNow := float64(time.Now().Unix())
 			switch licenseType {
-			case "oss", "jcr edition":
+			case "oss", "jcr edition", "community edition for c/c++":
 				validThrough = timeNow
 			default:
 				if validThroughTime, err := time.Parse("Jan 2, 2006", license.ValidThrough); err != nil {


### PR DESCRIPTION
resolve #90

Check working with Artifactory Community Edition for C/C++ is successful:
`artifactory_exporter    | level=info ts=2022-12-28T15:58:46.445Z caller=artifactory_exporter.go:30 msg="Starting artifactory_exporter" version="(version=, branch=, revision=)"
artifactory_exporter    | level=info ts=2022-12-28T15:58:46.445Z caller=artifactory_exporter.go:31 msg="Build context" context="(go=go1.18.9, user=, date=)"
artifactory_exporter    | level=info ts=2022-12-28T15:58:46.445Z caller=artifactory_exporter.go:32 msg="Listening on address" address=:9531
root@conan:/opt/dc-deploy/artifactory_exporter# docker-compose logs
Attaching to artifactory_exporter
artifactory_exporter    | level=info ts=2022-12-28T15:58:46.445Z caller=artifactory_exporter.go:30 msg="Starting artifactory_exporter" version="(version=, branch=, revision=)"
artifactory_exporter    | level=info ts=2022-12-28T15:58:46.445Z caller=artifactory_exporter.go:31 msg="Build context" context="(go=go1.18.9, user=, date=)"
artifactory_exporter    | level=info ts=2022-12-28T15:58:46.445Z caller=artifactory_exporter.go:32 msg="Listening on address" address=:9531
artifactory_exporter    | level=debug ts=2022-12-28T15:58:59.606Z caller=system.go:77 msg="Fetching license stats"
artifactory_exporter    | level=debug ts=2022-12-28T15:58:59.608Z caller=utils.go:44 msg="Fetching http" path=http://artifactory:8081/artifactory/api/system/license
artifactory_exporter    | level=debug ts=2022-12-28T15:58:59.635Z caller=system.go:23 msg="Fetching health stats"
artifactory_exporter    | level=debug ts=2022-12-28T15:58:59.635Z caller=utils.go:44 msg="Fetching http" path=http://artifactory:8081/artifactory/api/system/ping
artifactory_exporter    | level=debug ts=2022-12-28T15:58:59.641Z caller=system.go:31 msg="System ping returned OK"
artifactory_exporter    | level=debug ts=2022-12-28T15:58:59.641Z caller=system.go:50 msg="Fetching build stats"
artifactory_exporter    | level=debug ts=2022-12-28T15:58:59.641Z caller=utils.go:44 msg="Fetching http" path=http://artifactory:8081/artifactory/api/system/version
artifactory_exporter    | level=debug ts=2022-12-28T15:58:59.646Z caller=storageinfo.go:46 msg="Fetching storage info stats"
artifactory_exporter    | level=debug ts=2022-12-28T15:58:59.646Z caller=utils.go:44 msg="Fetching http" path=http://artifactory:8081/artifactory/api/storageinfo
artifactory_exporter    | level=debug ts=2022-12-28T15:58:59.652Z caller=utils.go:13 msg="Removing other characters to extract number from string"
artifactory_exporter    | level=debug ts=2022-12-28T15:58:59.652Z caller=utils.go:24 msg="Successfully converted string to number" string=57,733 number=57733
artifactory_exporter    | level=debug ts=2022-12-28T15:58:59.652Z caller=storage.go:24 msg="Registering metric" metric=binaries value=57733
artifactory_exporter    | level=debug ts=2022-12-28T15:58:59.652Z caller=utils.go:30 msg="Converting size to bytes"
artifactory_exporter    | level=debug ts=2022-12-28T15:58:59.652Z caller=utils.go:13 msg="Removing other characters to extract number from string"
artifactory_exporter    | level=debug ts=2022-12-28T15:58:59.652Z caller=utils.go:24 msg="Successfully converted string to number" string="393.40 GB" number=393.4
artifactory_exporter    | level=debug ts=2022-12-28T15:58:59.652Z caller=utils.go:49 msg="Successfully converted string to bytes" string="393.40 GB" value=4.224100335616e+11
artifactory_exporter    | level=debug ts=2022-12-28T15:58:59.652Z caller=storage.go:54 msg="Registering metric" metric=filestore value=4.224100335616e+11
artifactory_exporter    | level=debug ts=2022-12-28T15:58:59.652Z caller=utils.go:30 msg="Converting size to bytes"`