### PR TITLE
Add federated repo status metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ _See [helm install](https://helm.sh/docs/helm/helm_install/) for command documen
 
 ```bash
 $  docker run peimanja/artifactory_exporter:latest -h
-usage: main --artifactory.user=ARTIFACTORY.USER [<flags>]
+usage: artifactory_exporter [<flags>]
 
 Flags:
   -h, --help                    Show context-sensitive help (also try --help-long and --help-man).
@@ -183,6 +183,12 @@ Some metrics are not available with Artifactory OSS license. The exporter return
 | artifactory_system_healthy | Is Artifactory working properly (1 = healthy). | | &#9989; |
 | artifactory_system_license | License type and expiry as labels, seconds to expiration as value | `type`, `licensed_to`, `expires` | &#9989; |
 | artifactory_system_version | Version and revision of Artifactory as labels. | `version`, `revision` | &#9989; |
+| artifactory_federation_mirror_lag | Federation mirror lag in milliseconds. | `name`, `remote_url`, `remote_name` | |
+| artifactory_federation_mirror_status | Federation mirror status (1 = healthy). | `status`, `name`, `remote_url`, `remote_name` | |
+| artifactory_federation_unavailable_mirror | Unsynchronized federated mirror status. | `status`, `name`, `remote_url`, `remote_name` | |
+
+* Common labels:
+  * `node_id`: Artifactory node ID that the metric is scraped from.
 
 #### Optional metrics
 
@@ -191,11 +197,27 @@ Some metrics are expensive to compute and are disabled by default. To enable the
 Supported optional metrics:
 
 * `replication_status` - Extracts status of replication for each repository which has replication enabled. Enabling this will add the `status` label to `artifactory_replication_enabled` metric.
+* `federation_status` - Extracts repo federation metrics. Enabling this will add three new metrics: `artifactory_federation_mirror_lag`, `artifactory_federation_mirror_status` and `artifactory_federation_unavailable_mirror`. Please note that these metrics are only available in Artifactory Enterprise Plus and version 7.18.3 and above.
 
 ### Grafana Dashboard
 
 Dashboard can be found [here](https://grafana.com/grafana/dashboards/12113).
 
-
 ![Grafana dDashboard](/grafana/dashboard-screenshot-1.png)
 ![Grafana dDashboard](/grafana/dashboard-screenshot-2.png)
+
+### Common Issues
+
+In most cases enabling debug logs will help to identify the issue. To enable debug logs, use `--log.level=debug` flag.
+
+#### No metrics are being scraped
+
+* Check if the exporter is running and listening on the port specified by `--web.listen-address` flag.
+* Check if `artifactory_up` metric is `1` or `0`. If it is `0`, check the logs for the error message.
+* Check if `artifactory_exporter_total_api_errors` metric is `0`. If it is not `0` and it is increasing, check the logs for the error message.
+
+#### Some metrics or labels are missing
+
+* Check the logs to see if there are any timeouts or errors while scraping for metrics. In a large Artifactory instance, it may take a long time to scrape for all metrics especially `artifactory_artifacts_*` metrics. If there are any errors, try increasing the default timeout(5s) using `--timeout` flag.
+* Some metrics are not available based on your version or license type. Check the [metrics](###metrics) section to see if the metric is available for your license type.
+* Some metrics are optional and are disabled by default. Check the [optional metrics](###optional-metrics) section to see available optional metrics. You can enable them using `--optional-metric=metric_name` flag. You can pass this flag multiple times to enable multiple optional metrics.

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Some metrics are not available with Artifactory OSS license. The exporter return
 | artifactory_system_license | License type and expiry as labels, seconds to expiration as value | `type`, `licensed_to`, `expires` | &#9989; |
 | artifactory_system_version | Version and revision of Artifactory as labels. | `version`, `revision` | &#9989; |
 | artifactory_federation_mirror_lag | Federation mirror lag in milliseconds. | `name`, `remote_url`, `remote_name` | |
-| artifactory_federation_mirror_status | Federation mirror status (1 = healthy). | `status`, `name`, `remote_url`, `remote_name` | |
+| artifactory_federation_mirror_status | Federation mirror status. | `status`, `name`, `remote_url`, `remote_name` | |
 | artifactory_federation_unavailable_mirror | Unsynchronized federated mirror status. | `status`, `name`, `remote_url`, `remote_name` | |
 
 * Common labels:

--- a/artifactory/federation.go
+++ b/artifactory/federation.go
@@ -1,0 +1,146 @@
+package artifactory
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-kit/kit/log/level"
+)
+
+const federationMirrorsLagEndpoint = "federation/status/mirrorsLag"
+const federationUnavailableMirrorsEndpoint = "federation/status/unavailableMirrors"
+const federationRepoStatusEndpoint = "federation/status/repo"
+
+// IsFederationEnabled checks one of the federation endpoints to see if federation is enabled
+func (c *Client) IsFederationEnabled() bool {
+	_, err := c.FetchHTTP(federationUnavailableMirrorsEndpoint)
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+// MirrorLag represents single element of API respond from federation/status/mirrorsLag endpoint
+type MirrorLag struct {
+	LocalRepoKey  string `json:"localRepoKey"`
+	RemoteUrl     string `json:"remoteUrl"`
+	RemoteRepoKey string `json:"remoteRepoKey"`
+	LagInMS       int    `json:"lagInMS"`
+}
+
+type MirrorLags struct {
+	MirrorLags []MirrorLag
+	NodeId     string
+}
+
+// FetchMirrorLags makes the API call to federation/status/mirrorsLag endpoint and returns []MirrorLag
+func (c *Client) FetchMirrorLags() (MirrorLags, error) {
+	var mirrorLags MirrorLags
+	level.Debug(c.logger).Log("msg", "Fetching mirror lags")
+	resp, err := c.FetchHTTP(federationMirrorsLagEndpoint)
+	if err != nil {
+		if err.(*APIError).status == 404 {
+			return mirrorLags, nil
+		}
+		return mirrorLags, err
+	}
+	mirrorLags.NodeId = resp.NodeId
+
+	if err := json.Unmarshal(resp.Body, &mirrorLags.MirrorLags); err != nil {
+		level.Error(c.logger).Log("msg", "There was an issue when try to unmarshal mirror lags respond")
+		return mirrorLags, &UnmarshalError{
+			message:  err.Error(),
+			endpoint: federationMirrorsLagEndpoint,
+		}
+	}
+
+	return mirrorLags, nil
+}
+
+// UnavailableMirror represents single element of API respond from federation/status/unavailableMirrors endpoint
+type UnavailableMirror struct {
+	LocalRepoKey  string `json:"localRepoKey"`
+	RemoteUrl     string `json:"remoteUrl"`
+	RemoteRepoKey string `json:"remoteRepoKey"`
+	Status        string `json:"status"`
+}
+
+type UnavailableMirrors struct {
+	UnavailableMirrors []UnavailableMirror
+	NodeId             string
+}
+
+// FetchUnavailableMirrors makes the API call to federation/status/unavailableMirrors endpoint and returns []UnavailableMirror
+func (c *Client) FetchUnavailableMirrors() (UnavailableMirrors, error) {
+	var unavailableMirrors UnavailableMirrors
+	level.Debug(c.logger).Log("msg", "Fetching unavailable mirrors")
+	resp, err := c.FetchHTTP(federationUnavailableMirrorsEndpoint)
+	if err != nil {
+		if err.(*APIError).status == 404 {
+			return unavailableMirrors, nil
+		}
+		return unavailableMirrors, err
+	}
+	unavailableMirrors.NodeId = resp.NodeId
+
+	if err := json.Unmarshal(resp.Body, &unavailableMirrors.UnavailableMirrors); err != nil {
+		level.Error(c.logger).Log("msg", "There was an issue when try to unmarshal unavailable mirrors respond")
+		return unavailableMirrors, &UnmarshalError{
+			message:  err.Error(),
+			endpoint: federationUnavailableMirrorsEndpoint,
+		}
+	}
+
+	return unavailableMirrors, nil
+}
+
+// FederatedRepoStatus represents single element of API respond from federation/status/repo/<repoKey> endpoint
+// We don't need all the fields but we'll leave them here for future use
+type FederatedRepoStatus struct {
+	LocalKey          string `json:"localKey"`
+	BinariesTasksInfo struct {
+		InProgressTasks int `json:"inProgressTasks"`
+		FailingTasks    int `json:"failingTasks"`
+	} `json:"binariesTasksInfo"`
+	MirrorEventsStatusInfo []struct {
+		RemoteUrl     string `json:"remoteUrl"`
+		RemoteRepoKey string `json:"remoteRepoKey"`
+		Status        string `json:"status"`
+		CreateEvents  int    `json:"createEvents"`
+		UpdateEvents  int    `json:"updateEvents"`
+		DeleteEvents  int    `json:"deleteEvents"`
+		PropsEvents   int    `json:"propsEvents"`
+		ErrorEvents   int    `json:"errorEvents"`
+		LagInMS       int    `json:"lagInMS"`
+	} `json:"mirrorEventsStatusInfo"`
+	FederatedArtifactStatus struct {
+		CountFullyReplicateArtifacts         int `json:"countFullyReplicateArtifacts"`
+		CountArtificiallyReplicatedArtifacts int `json:"countArtificiallyReplicatedArtifacts"`
+	} `json:"federatedArtifactStatus"`
+	NodeId string
+}
+
+// FetchFederatedRepoStatus makes the API call to federation/status/repo/<repoKey> endpoint and returns FederatedRepoStatus
+func (c *Client) FetchFederatedRepoStatus(repoKey string) (FederatedRepoStatus, error) {
+	var federatedRepoStatus FederatedRepoStatus
+	level.Debug(c.logger).Log("msg", "Fetching federated repo status")
+	resp, err := c.FetchHTTP(fmt.Sprintf("%s/%s", federationRepoStatusEndpoint, repoKey))
+	if err != nil {
+		if err.(*APIError).status == 404 {
+			return federatedRepoStatus, nil
+		}
+		return federatedRepoStatus, err
+	}
+
+	federatedRepoStatus.NodeId = resp.NodeId
+
+	if err := json.Unmarshal(resp.Body, &federatedRepoStatus); err != nil {
+		level.Error(c.logger).Log("msg", "There was an issue when try to unmarshal federated repo status respond")
+		return federatedRepoStatus, &UnmarshalError{
+			message:  err.Error(),
+			endpoint: fmt.Sprintf("%s/%s", federationRepoStatusEndpoint, repoKey),
+		}
+	}
+
+	return federatedRepoStatus, nil
+}

--- a/artifactory/replication.go
+++ b/artifactory/replication.go
@@ -25,6 +25,7 @@ type Replication struct {
 	SyncStatistics                  bool   `json:"syncStatistics"`
 	Status                          string `json:"status"`
 }
+
 type Replications struct {
 	Replications []Replication
 	NodeId       string

--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -12,8 +12,9 @@ import (
 // Exporter collects JFrog Artifactory stats from the given URI and
 // exports them using the prometheus metrics package.
 type Exporter struct {
-	client *artifactory.Client
-	mutex  sync.RWMutex
+	client          *artifactory.Client
+	optionalMetrics config.OptionalMetrics
+	mutex           sync.RWMutex
 
 	up                                              prometheus.Gauge
 	totalScrapes, totalAPIErrors, jsonParseFailures prometheus.Counter
@@ -24,7 +25,8 @@ type Exporter struct {
 func NewExporter(conf *config.Config) (*Exporter, error) {
 	client := artifactory.NewClient(conf)
 	return &Exporter{
-		client: client,
+		client:          client,
+		optionalMetrics: conf.OptionalMetrics,
 		up: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "up",

--- a/collector/federation.go
+++ b/collector/federation.go
@@ -1,0 +1,91 @@
+package collector
+
+import (
+	"strings"
+
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const FederationRepoType = "FEDERATED"
+
+func (e *Exporter) exportFederationMirrorLags(ch chan<- prometheus.Metric) error {
+	// Fetch Federation Mirror Lags
+	federationMirrorLags, err := e.client.FetchMirrorLags()
+	if err != nil {
+		e.totalAPIErrors.Inc()
+		return err
+	}
+
+	if len(federationMirrorLags.MirrorLags) == 0 {
+		level.Debug(e.logger).Log("msg", "No federation mirror lags found")
+		return nil
+	}
+
+	for _, mirrorLag := range federationMirrorLags.MirrorLags {
+		level.Debug(e.logger).Log("msg", "Registering metric", "metric", "federationMirrorLag", "repo", mirrorLag.LocalRepoKey, "remote_url", mirrorLag.RemoteUrl, "remote_name", mirrorLag.RemoteRepoKey, "value", mirrorLag.LagInMS)
+		ch <- prometheus.MustNewConstMetric(federationMetrics["mirrorLag"], prometheus.GaugeValue, float64(mirrorLag.LagInMS), mirrorLag.LocalRepoKey, mirrorLag.RemoteUrl, mirrorLag.RemoteRepoKey, federationMirrorLags.NodeId)
+	}
+
+	return nil
+}
+
+func (e *Exporter) exportFederationUnavailableMirrors(ch chan<- prometheus.Metric) error {
+	// Fetch Federation Unavailable Mirrors
+	federationUnavailableMirrors, err := e.client.FetchUnavailableMirrors()
+	if err != nil {
+		e.totalAPIErrors.Inc()
+		return err
+	}
+
+	if len(federationUnavailableMirrors.UnavailableMirrors) == 0 {
+		level.Debug(e.logger).Log("msg", "No federation unavailable mirrors found")
+		return nil
+	}
+
+	for _, unavailableMirror := range federationUnavailableMirrors.UnavailableMirrors {
+		level.Debug(e.logger).Log("msg", "Registering metric", "metric", "federationUnavailableMirror", "status", unavailableMirror.Status, "repo", unavailableMirror.LocalRepoKey, "remote_url", unavailableMirror.RemoteUrl, "remote_name", unavailableMirror.RemoteRepoKey)
+		ch <- prometheus.MustNewConstMetric(federationMetrics["unavailableMirror"], prometheus.GaugeValue, 1, unavailableMirror.Status, unavailableMirror.LocalRepoKey, unavailableMirror.RemoteUrl, unavailableMirror.RemoteRepoKey, federationUnavailableMirrors.NodeId)
+	}
+
+	return nil
+}
+
+func (e *Exporter) getFederatedRepos(repoSummary []repoSummary) []string {
+	var federatedRepos []string
+	for _, repo := range repoSummary {
+		if repo.Type == strings.ToLower(FederationRepoType) {
+			federatedRepos = append(federatedRepos, repo.Name)
+		}
+	}
+	return federatedRepos
+}
+
+func (e *Exporter) exportFederationRepoStatus(repoSummary []repoSummary, ch chan<- prometheus.Metric) error {
+	repoList := e.getFederatedRepos(repoSummary)
+	if len(repoList) == 0 {
+		level.Debug(e.logger).Log("msg", "No federated repos found")
+		return nil
+	}
+
+	for _, repo := range repoList {
+		// Fetch Federation Repo Status
+		federationRepoStatus, err := e.client.FetchFederatedRepoStatus(repo)
+		if err != nil {
+			e.totalAPIErrors.Inc()
+			return err
+		}
+
+		// Check if the respond is not empty (depends on the Artifactory version)
+		if federationRepoStatus.LocalKey == "" {
+			level.Debug(e.logger).Log("msg", "No federation repo status found", "repo", repo)
+			return nil
+		}
+
+		for _, mirrorEventsStatusInfo := range federationRepoStatus.MirrorEventsStatusInfo {
+			level.Debug(e.logger).Log("msg", "Registering metric", "metric", "federationRepoStatus", "status", mirrorEventsStatusInfo.Status, "repo", repo, "remote_url", mirrorEventsStatusInfo.RemoteUrl, "remote_name", mirrorEventsStatusInfo.RemoteRepoKey)
+			ch <- prometheus.MustNewConstMetric(federationMetrics["repoStatus"], prometheus.GaugeValue, 1, mirrorEventsStatusInfo.Status, repo, mirrorEventsStatusInfo.RemoteUrl, mirrorEventsStatusInfo.RemoteRepoKey, federationRepoStatus.NodeId)
+		}
+	}
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,7 @@ var (
 	optionalMetrics = kingpin.Flag("optional-metric", "optional metric to be enabled. Pass multiple times to enable multiple optional metrics.").PlaceHolder("metric-name").Strings()
 )
 
-var optionalMetricsList = []string{"replication_status"}
+var optionalMetricsList = []string{"replication_status", "federation_status"}
 
 // Credentials represents Username and Password or API Key for
 // Artifactory Authentication
@@ -35,6 +35,7 @@ type Credentials struct {
 
 type OptionalMetrics struct {
 	ReplicationStatus bool
+	FederationStatus  bool
 }
 
 // Config represents all configuration options for running the Exporter.
@@ -82,6 +83,8 @@ func NewConfig() (*Config, error) {
 		switch metric {
 		case "replication_status":
 			optMetrics.ReplicationStatus = true
+		case "federation_status":
+			optMetrics.FederationStatus = true
 		default:
 			return nil, fmt.Errorf("unknown optional metric: %s. Valid optional metrics are: %s", metric, optionalMetricsList)
 		}


### PR DESCRIPTION
fixes #92 
Add new optional metrics to collect status of federated repos:

| Metric | Description | Labels |
| ------ | ----------- | ------ | ------ |
| artifactory_federation_mirror_lag | Federation mirror lag in milliseconds. | `name`, `remote_url`, `remote_name` |
| artifactory_federation_mirror_status | Federation mirror status. | `status`, `name`, `remote_url`, `remote_name` |
| artifactory_federation_unavailable_mirror | Unsynchronized federated mirror status. | `status`, `name`, `remote_url`, `remote_name` |

Enable this by passing `--optional-metric=federation_status` flag

Also added `Common Issues` section in the README