### PR TITLE
Remove federation repo status

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,6 @@ Some metrics are not available with Artifactory OSS license. The exporter return
 | artifactory_system_version | Version and revision of Artifactory as labels. | `version`, `revision` | &#9989; |
 | artifactory_federation_mirror_lag | Federation mirror lag in milliseconds. | `name`, `remote_url`, `remote_name` | |
 | artifactory_federation_unavailable_mirror | Unsynchronized federated mirror status. | `status`, `name`, `remote_url`, `remote_name` | |
-| artifactory_federation_repo_status | Synchronization status of the Federation for a repository | `status`, `name`, `remote_url`, `remote_name` | |
 
 * Common labels:
   * `node_id`: Artifactory node ID that the metric is scraped from.
@@ -200,7 +199,7 @@ Some metrics are expensive to compute and are disabled by default. To enable the
 Supported optional metrics:
 
 * `replication_status` - Extracts status of replication for each repository which has replication enabled. Enabling this will add the `status` label to `artifactory_replication_enabled` metric.
-* `federation_status` - Extracts repo federation metrics. Enabling this will add three new metrics: `artifactory_federation_mirror_lag`, `artifactory_federation_mirror_status` and `artifactory_federation_unavailable_mirror`. Please note that these metrics are only available in Artifactory Enterprise Plus and version 7.18.3 and above.
+* `federation_status` - Extracts federation metrics. Enabling this will add two new metrics: `artifactory_federation_mirror_lag`, and `artifactory_federation_unavailable_mirror`. Please note that these metrics are only available in Artifactory Enterprise Plus and version 7.18.3 and above.
 
 ### Grafana Dashboard
 

--- a/artifactory/federation.go
+++ b/artifactory/federation.go
@@ -2,14 +2,12 @@ package artifactory
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/go-kit/kit/log/level"
 )
 
 const federationMirrorsLagEndpoint = "federation/status/mirrorsLag"
 const federationUnavailableMirrorsEndpoint = "federation/status/unavailableMirrors"
-const federationRepoStatusEndpoint = "federation/status/repo"
 
 // IsFederationEnabled checks one of the federation endpoints to see if federation is enabled
 func (c *Client) IsFederationEnabled() bool {
@@ -92,55 +90,4 @@ func (c *Client) FetchUnavailableMirrors() (UnavailableMirrors, error) {
 	}
 
 	return unavailableMirrors, nil
-}
-
-// FederatedRepoStatus represents single element of API respond from federation/status/repo/<repoKey> endpoint
-// We don't need all the fields but we'll leave them here for future use
-type FederatedRepoStatus struct {
-	LocalKey          string `json:"localKey"`
-	BinariesTasksInfo struct {
-		InProgressTasks int `json:"inProgressTasks"`
-		FailingTasks    int `json:"failingTasks"`
-	} `json:"binariesTasksInfo"`
-	MirrorEventsStatusInfo []struct {
-		RemoteUrl     string `json:"remoteUrl"`
-		RemoteRepoKey string `json:"remoteRepoKey"`
-		Status        string `json:"status"`
-		CreateEvents  int    `json:"createEvents"`
-		UpdateEvents  int    `json:"updateEvents"`
-		DeleteEvents  int    `json:"deleteEvents"`
-		PropsEvents   int    `json:"propsEvents"`
-		ErrorEvents   int    `json:"errorEvents"`
-		LagInMS       int    `json:"lagInMS"`
-	} `json:"mirrorEventsStatusInfo"`
-	FederatedArtifactStatus struct {
-		CountFullyReplicateArtifacts         int `json:"countFullyReplicateArtifacts"`
-		CountArtificiallyReplicatedArtifacts int `json:"countArtificiallyReplicatedArtifacts"`
-	} `json:"federatedArtifactStatus"`
-	NodeId string
-}
-
-// FetchFederatedRepoStatus makes the API call to federation/status/repo/<repoKey> endpoint and returns FederatedRepoStatus
-func (c *Client) FetchFederatedRepoStatus(repoKey string) (FederatedRepoStatus, error) {
-	var federatedRepoStatus FederatedRepoStatus
-	level.Debug(c.logger).Log("msg", "Fetching federated repo status")
-	resp, err := c.FetchHTTP(fmt.Sprintf("%s/%s", federationRepoStatusEndpoint, repoKey))
-	if err != nil {
-		if err.(*APIError).status == 404 {
-			return federatedRepoStatus, nil
-		}
-		return federatedRepoStatus, err
-	}
-
-	federatedRepoStatus.NodeId = resp.NodeId
-
-	if err := json.Unmarshal(resp.Body, &federatedRepoStatus); err != nil {
-		level.Error(c.logger).Log("msg", "There was an issue when try to unmarshal federated repo status respond")
-		return federatedRepoStatus, &UnmarshalError{
-			message:  err.Error(),
-			endpoint: fmt.Sprintf("%s/%s", federationRepoStatusEndpoint, repoKey),
-		}
-	}
-
-	return federatedRepoStatus, nil
 }

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -67,7 +67,6 @@ var (
 	federationMetrics = metrics{
 		"mirrorLag":         newMetric("mirror_lag", "federation", "Federation mirror lag in milliseconds.", federationLabelNames),
 		"unavailableMirror": newMetric("unavailable_mirror", "federation", "Unsynchronized federated mirror status", append([]string{"status"}, federationLabelNames...)),
-		"repoStatus":        newMetric("repo_status", "federation", "Synchronization status of the Federation for a repository.", append([]string{"status"}, federationLabelNames...)),
 	}
 )
 
@@ -185,8 +184,6 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) (up float64) {
 	if e.optionalMetrics.FederationStatus && e.client.IsFederationEnabled() {
 		e.exportFederationMirrorLags(ch)
 		e.exportFederationUnavailableMirrors(ch)
-		// Get Federation Repo Status
-		e.exportFederationRepoStatus(repoSummaryList, ch)
 	}
 
 	return 1


### PR DESCRIPTION
federation status per repo is heavy on Artifactory. Removing it from metrics to avoid impacting Artifactory performance