### PR TITLE
Make artifactory_artifacts_* metrics optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Some metrics are not available with Artifactory OSS license. The exporter return
 Some metrics are expensive to compute and are disabled by default. To enable them, use `--optional-metric=metric_name` flag. Use this with caution as it may impact the performance in Artifactory instances with many repositories.
 
 Supported optional metrics:
+
 * `artifacts` - Extracts number of artifacts created/downloaded for each repository. Enabling this will add `artifactory_artifacts_*` metrics. Please note that on large Artifactory instances, this may impact the performance.
 * `replication_status` - Extracts status of replication for each repository which has replication enabled. Enabling this will add the `status` label to `artifactory_replication_enabled` metric.
 * `federation_status` - Extracts federation metrics. Enabling this will add two new metrics: `artifactory_federation_mirror_lag`, and `artifactory_federation_unavailable_mirror`. Please note that these metrics are only available in Artifactory Enterprise Plus and version 7.18.3 and above.

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Some metrics are not available with Artifactory OSS license. The exporter return
 Some metrics are expensive to compute and are disabled by default. To enable them, use `--optional-metric=metric_name` flag. Use this with caution as it may impact the performance in Artifactory instances with many repositories.
 
 Supported optional metrics:
-
+* `artifacts` - Extracts number of artifacts created/downloaded for each repository. Enabling this will add `artifactory_artifacts_*` metrics. Please note that on large Artifactory instances, this may impact the performance.
 * `replication_status` - Extracts status of replication for each repository which has replication enabled. Enabling this will add the `status` label to `artifactory_replication_enabled` metric.
 * `federation_status` - Extracts federation metrics. Enabling this will add two new metrics: `artifactory_federation_mirror_lag`, and `artifactory_federation_unavailable_mirror`. Please note that these metrics are only available in Artifactory Enterprise Plus and version 7.18.3 and above.
 

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,7 @@ type Credentials struct {
 }
 
 type OptionalMetrics struct {
+	Artifacts         bool
 	ReplicationStatus bool
 	FederationStatus  bool
 }
@@ -81,6 +82,8 @@ func NewConfig() (*Config, error) {
 	optMetrics := OptionalMetrics{}
 	for _, metric := range *optionalMetrics {
 		switch metric {
+		case "artifacts":
+			optMetrics.Artifacts = true
 		case "replication_status":
 			optMetrics.ReplicationStatus = true
 		case "federation_status":


### PR DESCRIPTION
Fixes #104. `artifactory_artifacts_*` metrics run AQL queries and on large instances this may impact the performance. 