### PR TITLE
Update the go-kit/log package reference

### DIFF
--- a/artifactory/client.go
+++ b/artifactory/client.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"net/http"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/peimanja/artifactory_exporter/config"
 )
 

--- a/artifactory/federation.go
+++ b/artifactory/federation.go
@@ -3,7 +3,7 @@ package artifactory
 import (
 	"encoding/json"
 
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log/level"
 )
 
 const federationMirrorsLagEndpoint = "federation/status/mirrorsLag"

--- a/artifactory/replication.go
+++ b/artifactory/replication.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log/level"
 )
 
 const replicationEndpoint = "replications"

--- a/artifactory/security.go
+++ b/artifactory/security.go
@@ -3,7 +3,7 @@ package artifactory
 import (
 	"encoding/json"
 
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log/level"
 )
 
 const (

--- a/artifactory/storageinfo.go
+++ b/artifactory/storageinfo.go
@@ -3,7 +3,7 @@ package artifactory
 import (
 	"encoding/json"
 
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log/level"
 )
 
 const (

--- a/artifactory/system.go
+++ b/artifactory/system.go
@@ -3,7 +3,7 @@ package artifactory
 import (
 	"encoding/json"
 
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log/level"
 )
 
 const (

--- a/artifactory/utils.go
+++ b/artifactory/utils.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log/level"
 )
 
 // APIErrors represents Artifactory API Error response

--- a/artifactory_exporter.go
+++ b/artifactory_exporter.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log/level"
 	"github.com/peimanja/artifactory_exporter/collector"
 	"github.com/peimanja/artifactory_exporter/config"
 	"github.com/prometheus/client_golang/prometheus"

--- a/collector/artifacts.go
+++ b/collector/artifacts.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -3,7 +3,7 @@ package collector
 import (
 	"sync"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/peimanja/artifactory_exporter/artifactory"
 	"github.com/peimanja/artifactory_exporter/config"
 	"github.com/prometheus/client_golang/prometheus"

--- a/collector/federation.go
+++ b/collector/federation.go
@@ -1,7 +1,7 @@
 package collector
 
 import (
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collector/replication.go
+++ b/collector/replication.go
@@ -3,7 +3,7 @@ package collector
 import (
 	"strings"
 
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collector/security.go
+++ b/collector/security.go
@@ -3,7 +3,7 @@ package collector
 import (
 	"fmt"
 
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log/level"
 	"github.com/peimanja/artifactory_exporter/artifactory"
 	"github.com/prometheus/client_golang/prometheus"
 )

--- a/collector/storage.go
+++ b/collector/storage.go
@@ -3,7 +3,7 @@ package collector
 import (
 	"strings"
 
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log/level"
 	"github.com/peimanja/artifactory_exporter/artifactory"
 	"github.com/prometheus/client_golang/prometheus"
 )

--- a/collector/system.go
+++ b/collector/system.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log/level"
 	"github.com/peimanja/artifactory_exporter/artifactory"
 	"github.com/prometheus/client_golang/prometheus"
 )

--- a/collector/utils.go
+++ b/collector/utils.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log/level"
 )
 
 func (e *Exporter) removeCommas(str string) (float64, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/common/promlog/flag"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/peimanja/artifactory_exporter
 go 1.18
 
 require (
-	github.com/go-kit/kit v0.9.0
+	github.com/go-kit/log v0.1.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/prometheus/client_golang v1.11.1
 	github.com/prometheus/common v0.26.0
@@ -15,7 +15,6 @@ require (
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
-	github.com/go-kit/log v0.1.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.0 // indirect
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,7 +16,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
-github.com/go-kit/kit v0.9.0 h1:wDJmvq38kDhkVxi50ni9ykkdUr1PKgqKOoi01fa0Mdk=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0 h1:DGJh0Sm43HbOeYDNnVZFl8BvcYVvjD5bqYJvp0REbwQ=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=


### PR DESCRIPTION
Fixes #108 
>Deprecation notice: The core Go kit log packages (log, log/level, log/term, and log/syslog) have been moved to their own repository at github.com/go-kit/log. The corresponding packages in this directory remain for backwards compatibility. Their types alias the types and their functions call the functions provided by the new repository. Using either import path should be equivalent. Prefer the new import path when practical.