### PR TITLE
Can we replace `github.com/prometheus/common/log` with `log/slog`?

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     - uses: wangyoucao577/go-release-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        goversion: 1.18
+        goversion: 1.21
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
         release_tag: ${{ github.event.release.tag_name || github.event.inputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 as build
+FROM golang:1.21 as build
 
 WORKDIR /go/artifactory_exporter
 ADD . /go/artifactory_exporter

--- a/artifactory/client.go
+++ b/artifactory/client.go
@@ -2,9 +2,8 @@ package artifactory
 
 import (
 	"crypto/tls"
+	"log/slog"
 	"net/http"
-
-	"github.com/go-kit/log"
 
 	"github.com/peimanja/artifactory_exporter/config"
 )
@@ -16,7 +15,7 @@ type Client struct {
 	cred            config.Credentials
 	optionalMetrics config.OptionalMetrics
 	client          *http.Client
-	logger          log.Logger
+	logger          *slog.Logger
 }
 
 // NewClient returns an initialized Artifactory HTTP Client.

--- a/artifactory/federation.go
+++ b/artifactory/federation.go
@@ -2,8 +2,6 @@ package artifactory
 
 import (
 	"encoding/json"
-
-	"github.com/go-kit/log/level"
 )
 
 const federationMirrorsLagEndpoint = "federation/status/mirrorsLag"
@@ -34,7 +32,7 @@ type MirrorLags struct {
 // FetchMirrorLags makes the API call to federation/status/mirrorsLag endpoint and returns []MirrorLag
 func (c *Client) FetchMirrorLags() (MirrorLags, error) {
 	var mirrorLags MirrorLags
-	level.Debug(c.logger).Log("msg", "Fetching mirror lags")
+	c.logger.Debug("Fetching mirror lags")
 	resp, err := c.FetchHTTP(federationMirrorsLagEndpoint)
 	if err != nil {
 		if err.(*APIError).status == 404 {
@@ -45,7 +43,7 @@ func (c *Client) FetchMirrorLags() (MirrorLags, error) {
 	mirrorLags.NodeId = resp.NodeId
 
 	if err := json.Unmarshal(resp.Body, &mirrorLags.MirrorLags); err != nil {
-		level.Error(c.logger).Log("msg", "There was an issue when try to unmarshal mirror lags respond")
+		c.logger.Error("There was an issue when try to unmarshal mirror lags respond")
 		return mirrorLags, &UnmarshalError{
 			message:  err.Error(),
 			endpoint: federationMirrorsLagEndpoint,
@@ -71,7 +69,7 @@ type UnavailableMirrors struct {
 // FetchUnavailableMirrors makes the API call to federation/status/unavailableMirrors endpoint and returns []UnavailableMirror
 func (c *Client) FetchUnavailableMirrors() (UnavailableMirrors, error) {
 	var unavailableMirrors UnavailableMirrors
-	level.Debug(c.logger).Log("msg", "Fetching unavailable mirrors")
+	c.logger.Debug("Fetching unavailable mirrors")
 	resp, err := c.FetchHTTP(federationUnavailableMirrorsEndpoint)
 	if err != nil {
 		if err.(*APIError).status == 404 {
@@ -82,7 +80,7 @@ func (c *Client) FetchUnavailableMirrors() (UnavailableMirrors, error) {
 	unavailableMirrors.NodeId = resp.NodeId
 
 	if err := json.Unmarshal(resp.Body, &unavailableMirrors.UnavailableMirrors); err != nil {
-		level.Error(c.logger).Log("msg", "There was an issue when try to unmarshal unavailable mirrors respond")
+		c.logger.Error("There was an issue when try to unmarshal unavailable mirrors respond")
 		return unavailableMirrors, &UnmarshalError{
 			message:  err.Error(),
 			endpoint: federationUnavailableMirrorsEndpoint,

--- a/artifactory/openmetrics.go
+++ b/artifactory/openmetrics.go
@@ -1,9 +1,5 @@
 package artifactory
 
-import (
-	"github.com/go-kit/log/level"
-)
-
 const openMetricsEndpoint = "v1/metrics"
 
 type OpenMetrics struct {
@@ -14,7 +10,7 @@ type OpenMetrics struct {
 // FetchOpenMetrics makes the API call to open metrics endpoint and returns all the open metrics
 func (c *Client) FetchOpenMetrics() (OpenMetrics, error) {
 	var openMetrics OpenMetrics
-	level.Debug(c.logger).Log("msg", "Fetching openMetrics")
+	c.logger.Debug("Fetching openMetrics")
 	resp, err := c.FetchHTTP(openMetricsEndpoint)
 	if err != nil {
 		if err.(*APIError).status == 404 {
@@ -23,7 +19,10 @@ func (c *Client) FetchOpenMetrics() (OpenMetrics, error) {
 		return openMetrics, err
 	}
 
-	level.Debug(c.logger).Log("msg", "OpenMetrics from Artifactory", "body", string(resp.Body))
+	c.logger.Debug(
+		"OpenMetrics from Artifactory",
+		"body", string(resp.Body),
+	)
 
 	openMetrics.NodeId = resp.NodeId
 	openMetrics.PromMetrics = string(resp.Body)

--- a/artifactory/replication.go
+++ b/artifactory/replication.go
@@ -3,8 +3,6 @@ package artifactory
 import (
 	"encoding/json"
 	"fmt"
-
-	"github.com/go-kit/log/level"
 )
 
 const replicationEndpoint = "replications"
@@ -38,7 +36,7 @@ type ReplicationStatus struct {
 // FetchReplications makes the API call to replication endpoint and returns []Replication
 func (c *Client) FetchReplications() (Replications, error) {
 	var replications Replications
-	level.Debug(c.logger).Log("msg", "Fetching replications stats")
+	c.logger.Debug("Fetching replications stats")
 	resp, err := c.FetchHTTP(replicationEndpoint)
 	if err != nil {
 		if err.(*APIError).status == 404 {
@@ -49,7 +47,7 @@ func (c *Client) FetchReplications() (Replications, error) {
 	replications.NodeId = resp.NodeId
 
 	if err := json.Unmarshal(resp.Body, &replications.Replications); err != nil {
-		level.Error(c.logger).Log("msg", "There was an issue when try to unmarshal replication respond")
+		c.logger.Error("There was an issue when try to unmarshal replication respond")
 		return replications, &UnmarshalError{
 			message:  err.Error(),
 			endpoint: replicationEndpoint,
@@ -57,7 +55,7 @@ func (c *Client) FetchReplications() (Replications, error) {
 	}
 
 	if c.optionalMetrics.ReplicationStatus {
-		level.Debug(c.logger).Log("msg", "Fetching replications status")
+		c.logger.Debug("Fetching replications status")
 		for i, replication := range replications.Replications {
 			var status ReplicationStatus
 			if replication.Enabled {
@@ -66,7 +64,7 @@ func (c *Client) FetchReplications() (Replications, error) {
 					return replications, err
 				}
 				if err := json.Unmarshal(statusResp.Body, &status); err != nil {
-					level.Error(c.logger).Log("msg", "There was an issue when try to unmarshal replication status respond")
+					c.logger.Error("There was an issue when try to unmarshal replication status respond")
 					return replications, &UnmarshalError{
 						message:  err.Error(),
 						endpoint: fmt.Sprintf("%s/%s", replicationStatusEndpoint, replication.RepoKey),

--- a/artifactory/security.go
+++ b/artifactory/security.go
@@ -2,8 +2,6 @@ package artifactory
 
 import (
 	"encoding/json"
-
-	"github.com/go-kit/log/level"
 )
 
 const (
@@ -24,14 +22,14 @@ type Users struct {
 // FetchUsers makes the API call to users endpoint and returns []User
 func (c *Client) FetchUsers() (Users, error) {
 	var users Users
-	level.Debug(c.logger).Log("msg", "Fetching users stats")
+	c.logger.Debug("Fetching users stats")
 	resp, err := c.FetchHTTP(usersEndpoint)
 	if err != nil {
 		return users, err
 	}
 	users.NodeId = resp.NodeId
 	if err := json.Unmarshal(resp.Body, &users.Users); err != nil {
-		level.Error(c.logger).Log("msg", "There was an issue when try to unmarshal users respond")
+		c.logger.Error("There was an issue when try to unmarshal users respond")
 		return users, &UnmarshalError{
 			message:  err.Error(),
 			endpoint: usersEndpoint,
@@ -53,14 +51,14 @@ type Groups struct {
 // FetchGroups makes the API call to groups endpoint and returns []Group
 func (c *Client) FetchGroups() (Groups, error) {
 	var groups Groups
-	level.Debug(c.logger).Log("msg", "Fetching groups stats")
+	c.logger.Debug("Fetching groups stats")
 	resp, err := c.FetchHTTP(groupsEndpoint)
 	if err != nil {
 		return groups, err
 	}
 	groups.NodeId = resp.NodeId
 	if err := json.Unmarshal(resp.Body, &groups.Groups); err != nil {
-		level.Error(c.logger).Log("msg", "There was an issue when try to unmarshal groups respond")
+		c.logger.Error("There was an issue when try to unmarshal groups respond")
 		return groups, &UnmarshalError{
 			message:  err.Error(),
 			endpoint: groupsEndpoint,

--- a/artifactory/storageinfo.go
+++ b/artifactory/storageinfo.go
@@ -2,8 +2,6 @@ package artifactory
 
 import (
 	"encoding/json"
-
-	"github.com/go-kit/log/level"
 )
 
 const (
@@ -43,14 +41,14 @@ type StorageInfo struct {
 // FetchStorageInfo makes the API call to storageinfo endpoint and returns StorageInfo
 func (c *Client) FetchStorageInfo() (StorageInfo, error) {
 	var storageInfo StorageInfo
-	level.Debug(c.logger).Log("msg", "Fetching storage info stats")
+	c.logger.Debug("Fetching storage info stats")
 	resp, err := c.FetchHTTP(storageInfoEndpoint)
 	if err != nil {
 		return storageInfo, err
 	}
 	storageInfo.NodeId = resp.NodeId
 	if err := json.Unmarshal(resp.Body, &storageInfo); err != nil {
-		level.Error(c.logger).Log("msg", "There was an issue when try to unmarshal storageInfo respond")
+		c.logger.Error("There was an issue when try to unmarshal storageInfo respond")
 		return storageInfo, &UnmarshalError{
 			message:  err.Error(),
 			endpoint: storageInfoEndpoint,

--- a/artifactory/system.go
+++ b/artifactory/system.go
@@ -2,8 +2,6 @@ package artifactory
 
 import (
 	"encoding/json"
-
-	"github.com/go-kit/log/level"
 )
 
 const (
@@ -20,7 +18,7 @@ type HealthStatus struct {
 // FetchHealth returns true if the ping endpoint returns "OK"
 func (c *Client) FetchHealth() (HealthStatus, error) {
 	health := HealthStatus{Healthy: false}
-	level.Debug(c.logger).Log("msg", "Fetching health stats")
+	c.logger.Debug("Fetching health stats")
 	resp, err := c.FetchHTTP(pingEndpoint)
 	if err != nil {
 		return health, err
@@ -28,7 +26,7 @@ func (c *Client) FetchHealth() (HealthStatus, error) {
 	health.NodeId = resp.NodeId
 	bodyString := string(resp.Body)
 	if bodyString == "OK" {
-		level.Debug(c.logger).Log("msg", "System ping returned OK")
+		c.logger.Debug("System ping returned OK")
 		health.Healthy = true
 		return health, nil
 	}
@@ -47,14 +45,14 @@ type BuildInfo struct {
 // FetchBuildInfo makes the API call to version endpoint and returns BuildInfo
 func (c *Client) FetchBuildInfo() (BuildInfo, error) {
 	var buildInfo BuildInfo
-	level.Debug(c.logger).Log("msg", "Fetching build stats")
+	c.logger.Debug("Fetching build stats")
 	resp, err := c.FetchHTTP(versionEndpoint)
 	if err != nil {
 		return buildInfo, err
 	}
 	buildInfo.NodeId = resp.NodeId
 	if err := json.Unmarshal(resp.Body, &buildInfo); err != nil {
-		level.Error(c.logger).Log("msg", "There was an issue when try to unmarshal buildInfo respond")
+		c.logger.Error("There was an issue when try to unmarshal buildInfo respond")
 		return buildInfo, &UnmarshalError{
 			message:  err.Error(),
 			endpoint: versionEndpoint,
@@ -74,14 +72,14 @@ type LicenseInfo struct {
 // FetchLicense makes the API call to license endpoint and returns LicenseInfo
 func (c *Client) FetchLicense() (LicenseInfo, error) {
 	var licenseInfo LicenseInfo
-	level.Debug(c.logger).Log("msg", "Fetching license stats")
+	c.logger.Debug("Fetching license stats")
 	resp, err := c.FetchHTTP(licenseEndpoint)
 	if err != nil {
 		return licenseInfo, err
 	}
 	licenseInfo.NodeId = resp.NodeId
 	if err := json.Unmarshal(resp.Body, &licenseInfo); err != nil {
-		level.Error(c.logger).Log("msg", "There was an issue when try to unmarshal licenseInfo respond")
+		c.logger.Error("There was an issue when try to unmarshal licenseInfo respond")
 		return licenseInfo, &UnmarshalError{
 			message:  err.Error(),
 			endpoint: licenseEndpoint,

--- a/artifactory/utils.go
+++ b/artifactory/utils.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	msgErrAPICall    = "There was an error making API call"
-	msgErrUnmarshall = "There was an error when trying to unmarshal the API Error"
+	logMsgErrAPICall    = "There was an error making API call"
+	logMsgErrUnmarshall = "There was an error when trying to unmarshal the API Error"
 )
 
 // APIErrors represents Artifactory API Error response
@@ -64,7 +64,7 @@ func (c *Client) procRespErr(resp *http.Response, fPath string) (*ApiResponse, e
 	bodyBytes, _ := ioutil.ReadAll(resp.Body)
 	if err := json.Unmarshal(bodyBytes, &apiErrors); err != nil {
 		c.logger.Error(
-			msgErrUnmarshall,
+			logMsgErrUnmarshall,
 			"err", err.Error(),
 		)
 		return nil, &UnmarshalError{
@@ -73,7 +73,7 @@ func (c *Client) procRespErr(resp *http.Response, fPath string) (*ApiResponse, e
 		}
 	}
 	c.logger.Error(
-		msgErrAPICall,
+		logMsgErrAPICall,
 		"endpoint", fPath,
 		"err", fmt.Sprintf("%v", apiErrors.Errors),
 		"status", resp.StatusCode,
@@ -96,7 +96,7 @@ func (c *Client) FetchHTTP(path string) (*ApiResponse, error) {
 	resp, err := c.makeRequest("GET", fullPath, nil)
 	if err != nil {
 		c.logger.Error(
-			msgErrAPICall,
+			logMsgErrAPICall,
 			"endpoint", fullPath,
 			"err", err.Error(),
 		)
@@ -110,7 +110,7 @@ func (c *Client) FetchHTTP(path string) (*ApiResponse, error) {
 		bodyBytes, _ := ioutil.ReadAll(resp.Body)
 		if err := json.Unmarshal(bodyBytes, &apiErrors); err != nil {
 			c.logger.Error(
-				msgErrUnmarshall,
+				logMsgErrUnmarshall,
 				"err", err,
 			)
 			return nil, &UnmarshalError{
@@ -159,7 +159,7 @@ func (c *Client) QueryAQL(query []byte) (*ApiResponse, error) {
 	resp, err := c.makeRequest("POST", fullPath, query)
 	if err != nil {
 		c.logger.Error(
-			msgErrAPICall,
+			logMsgErrAPICall,
 			"endpoint", fullPath,
 			"err", err.Error(),
 		)

--- a/artifactory/utils.go
+++ b/artifactory/utils.go
@@ -8,6 +8,10 @@ import (
 	"net/http"
 )
 
+const (
+	msgErrAPICall = "There was an error making API call" // https://github.com/peimanja/artifactory_exporter/pull/121/checks?check_run_id=20136336585
+)
+
 // APIErrors represents Artifactory API Error response
 type APIErrors struct {
 	Errors interface{}
@@ -49,7 +53,7 @@ func (c *Client) FetchHTTP(path string) (*ApiResponse, error) {
 	resp, err := c.makeRequest("GET", fullPath, nil)
 	if err != nil {
 		c.logger.Error(
-			"There was an error making API call",
+			msgErrAPICall,
 			"endpoint", fullPath,
 			"err", err.Error(),
 		)
@@ -98,7 +102,7 @@ func (c *Client) FetchHTTP(path string) (*ApiResponse, error) {
 			}
 		}
 		c.logger.Error(
-			"There was an error making API call",
+			msgErrAPICall,
 			"endpoint", fullPath,
 			"err", fmt.Sprintf("%v", apiErrors.Errors),
 			"status", "is missing and should be provided", // Value from Kacper Perschke and should be changed to significant!
@@ -133,7 +137,7 @@ func (c *Client) QueryAQL(query []byte) (*ApiResponse, error) {
 	resp, err := c.makeRequest("POST", fullPath, query)
 	if err != nil {
 		c.logger.Error(
-			"There was an error making API call",
+			msgErrAPICall,
 			"endpoint", fullPath,
 			"err", err.Error(),
 		)
@@ -151,7 +155,7 @@ func (c *Client) QueryAQL(query []byte) (*ApiResponse, error) {
 			}
 		}
 		c.logger.Error(
-			"There was an error making API call",
+			msgErrAPICall,
 			"endpoint", fullPath,
 			"err", fmt.Sprintf("%v", apiErrors.Errors),
 			"status", "evaporated?", // Value from Kacper Perschke and should be changed to significant!

--- a/artifactory_exporter.go
+++ b/artifactory_exporter.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/version"
 
 	"github.com/peimanja/artifactory_exporter/collector"
@@ -18,7 +18,10 @@ import (
 func main() {
 	conf, err := config.NewConfig()
 	if err != nil {
-		log.Errorf("Error creating the config. err: %s", err)
+		slog.Error(
+			"Error creating the config.",
+			"err", err.Error(),
+		)
 		os.Exit(1)
 	}
 

--- a/collector/artifacts.go
+++ b/collector/artifacts.go
@@ -3,7 +3,7 @@ package collector
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/go-kit/log/level"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -20,14 +20,21 @@ type artifactQueryResult struct {
 func (e *Exporter) findArtifacts(period string, queryType string) (artifactQueryResult, error) {
 	var query string
 	artifacts := artifactQueryResult{}
-	level.Debug(e.logger).Log("msg", "Finding all artifacts", "period", period, "queryType", queryType)
+	e.logger.Debug(
+		"Finding all artifacts",
+		"period", period,
+		"queryType", queryType,
+	)
 	switch queryType {
 	case "created":
 		query = fmt.Sprintf("items.find({\"modified\" : {\"$last\" : \"%s\"}}).include(\"name\", \"repo\")", period)
 	case "downloaded":
 		query = fmt.Sprintf("items.find({\"stat.downloaded\" : {\"$last\" : \"%s\"}}).include(\"name\", \"repo\")", period)
 	default:
-		level.Error(e.logger).Log("err", "Query Type is not supported", "query", queryType)
+		e.logger.Error(
+			"Query Type is not supported",
+			"query", queryType,
+		)
 		return artifacts, fmt.Errorf("Query Type is not supported: %s", queryType)
 	}
 	resp, err := e.client.QueryAQL([]byte(query))
@@ -37,7 +44,12 @@ func (e *Exporter) findArtifacts(period string, queryType string) (artifactQuery
 	}
 	artifacts.NodeId = resp.NodeId
 	if err := json.Unmarshal(resp.Body, &artifacts); err != nil {
-		level.Warn(e.logger).Log("msg", "There was an error when trying to unmarshal AQL response", "queryType", queryType, "period", period, "error", err)
+		e.logger.Warn(
+			"There was an error when trying to unmarshal AQL response",
+			"queryType", queryType,
+			"period", period,
+			"error", err.Error(),
+		)
 		e.jsonParseFailures.Inc()
 		return artifacts, err
 	}
@@ -117,22 +129,64 @@ func (e *Exporter) exportArtifacts(repoSummaries []repoSummary, ch chan<- promet
 		for metricName, metric := range artifactsMetrics {
 			switch metricName {
 			case "created1m":
-				level.Debug(e.logger).Log("msg", "Registering metric", "metric", metricName, "repo", repoSummary.Name, "type", repoSummary.Type, "package_type", repoSummary.PackageType, "value", repoSummary.TotalCreate1m)
+				e.logger.Debug(
+					"Registering metric",
+					"metric", metricName,
+					"repo", repoSummary.Name,
+					"type", repoSummary.Type,
+					"package_type", repoSummary.PackageType,
+					"value", repoSummary.TotalCreate1m,
+				)
 				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, repoSummary.TotalCreate1m, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
 			case "created5m":
-				level.Debug(e.logger).Log("msg", "Registering metric", "metric", metricName, "repo", repoSummary.Name, "type", repoSummary.Type, "package_type", repoSummary.PackageType, "value", repoSummary.TotalCreated5m)
+				e.logger.Debug(
+					"Registering metric",
+					"metric", metricName,
+					"repo", repoSummary.Name,
+					"type", repoSummary.Type,
+					"package_type", repoSummary.PackageType,
+					"value", repoSummary.TotalCreated5m,
+				)
 				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, repoSummary.TotalCreated5m, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
 			case "created15m":
-				level.Debug(e.logger).Log("msg", "Registering metric", "metric", metricName, "repo", repoSummary.Name, "type", repoSummary.Type, "package_type", repoSummary.PackageType, "value", repoSummary.TotalCreated15m)
+				e.logger.Debug(
+					"Registering metric",
+					"metric", metricName,
+					"repo", repoSummary.Name,
+					"type", repoSummary.Type,
+					"package_type", repoSummary.PackageType,
+					"value", repoSummary.TotalCreated15m,
+				)
 				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, repoSummary.TotalCreated15m, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
 			case "downloaded1m":
-				level.Debug(e.logger).Log("msg", "Registering metric", "metric", metricName, "repo", repoSummary.Name, "type", repoSummary.Type, "package_type", repoSummary.PackageType, "value", repoSummary.TotalDownloaded1m)
+				e.logger.Debug(
+					"Registering metric",
+					"metric", metricName,
+					"repo", repoSummary.Name,
+					"type", repoSummary.Type,
+					"package_type", repoSummary.PackageType,
+					"value", repoSummary.TotalDownloaded1m,
+				)
 				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, repoSummary.TotalDownloaded1m, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
 			case "downloaded5m":
-				level.Debug(e.logger).Log("msg", "Registering metric", "metric", metricName, "repo", repoSummary.Name, "type", repoSummary.Type, "package_type", repoSummary.PackageType, "value", repoSummary.TotalDownloaded5m)
+				e.logger.Debug(
+					"Registering metric",
+					"metric", metricName,
+					"repo", repoSummary.Name,
+					"type", repoSummary.Type,
+					"package_type", repoSummary.PackageType,
+					"value", repoSummary.TotalDownloaded5m,
+				)
 				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, repoSummary.TotalDownloaded5m, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
 			case "downloaded15m":
-				level.Debug(e.logger).Log("msg", "Registering metric", "metric", metricName, "repo", repoSummary.Name, "type", repoSummary.Type, "package_type", repoSummary.PackageType, "value", repoSummary.TotalDownloaded15m)
+				e.logger.Debug(
+					"Registering metric",
+					"metric", metricName,
+					"repo", repoSummary.Name,
+					"type", repoSummary.Type,
+					"package_type", repoSummary.PackageType,
+					"value", repoSummary.TotalDownloaded15m,
+				)
 				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, repoSummary.TotalDownloaded15m, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
 			}
 		}

--- a/collector/artifacts.go
+++ b/collector/artifacts.go
@@ -130,7 +130,7 @@ func (e *Exporter) exportArtifacts(repoSummaries []repoSummary, ch chan<- promet
 			switch metricName {
 			case "created1m":
 				e.logger.Debug(
-					"Registering metric",
+					logDbgMsgRegMetric,
 					"metric", metricName,
 					"repo", repoSummary.Name,
 					"type", repoSummary.Type,
@@ -140,7 +140,7 @@ func (e *Exporter) exportArtifacts(repoSummaries []repoSummary, ch chan<- promet
 				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, repoSummary.TotalCreate1m, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
 			case "created5m":
 				e.logger.Debug(
-					"Registering metric",
+					logDbgMsgRegMetric,
 					"metric", metricName,
 					"repo", repoSummary.Name,
 					"type", repoSummary.Type,
@@ -150,7 +150,7 @@ func (e *Exporter) exportArtifacts(repoSummaries []repoSummary, ch chan<- promet
 				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, repoSummary.TotalCreated5m, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
 			case "created15m":
 				e.logger.Debug(
-					"Registering metric",
+					logDbgMsgRegMetric,
 					"metric", metricName,
 					"repo", repoSummary.Name,
 					"type", repoSummary.Type,
@@ -160,7 +160,7 @@ func (e *Exporter) exportArtifacts(repoSummaries []repoSummary, ch chan<- promet
 				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, repoSummary.TotalCreated15m, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
 			case "downloaded1m":
 				e.logger.Debug(
-					"Registering metric",
+					logDbgMsgRegMetric,
 					"metric", metricName,
 					"repo", repoSummary.Name,
 					"type", repoSummary.Type,
@@ -170,7 +170,7 @@ func (e *Exporter) exportArtifacts(repoSummaries []repoSummary, ch chan<- promet
 				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, repoSummary.TotalDownloaded1m, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
 			case "downloaded5m":
 				e.logger.Debug(
-					"Registering metric",
+					logDbgMsgRegMetric,
 					"metric", metricName,
 					"repo", repoSummary.Name,
 					"type", repoSummary.Type,
@@ -180,7 +180,7 @@ func (e *Exporter) exportArtifacts(repoSummaries []repoSummary, ch chan<- promet
 				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, repoSummary.TotalDownloaded5m, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
 			case "downloaded15m":
 				e.logger.Debug(
-					"Registering metric",
+					logDbgMsgRegMetric,
 					"metric", metricName,
 					"repo", repoSummary.Name,
 					"type", repoSummary.Type,

--- a/collector/common.go
+++ b/collector/common.go
@@ -1,0 +1,5 @@
+package collector
+
+const (
+	logDbgMsgRegMetric = "Registering metric"
+)

--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -1,9 +1,9 @@
 package collector
 
 import (
+	"log/slog"
 	"sync"
 
-	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/peimanja/artifactory_exporter/artifactory"
@@ -19,7 +19,7 @@ type Exporter struct {
 
 	up                                              prometheus.Gauge
 	totalScrapes, totalAPIErrors, jsonParseFailures prometheus.Counter
-	logger                                          log.Logger
+	logger                                          *slog.Logger
 }
 
 // NewExporter returns an initialized Exporter.

--- a/collector/federation.go
+++ b/collector/federation.go
@@ -1,7 +1,6 @@
 package collector
 
 import (
-	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -16,12 +15,19 @@ func (e *Exporter) exportFederationMirrorLags(ch chan<- prometheus.Metric) error
 	}
 
 	if len(federationMirrorLags.MirrorLags) == 0 {
-		level.Debug(e.logger).Log("msg", "No federation mirror lags found")
+		e.logger.Debug("No federation mirror lags found")
 		return nil
 	}
 
 	for _, mirrorLag := range federationMirrorLags.MirrorLags {
-		level.Debug(e.logger).Log("msg", "Registering metric", "metric", "federationMirrorLag", "repo", mirrorLag.LocalRepoKey, "remote_url", mirrorLag.RemoteUrl, "remote_name", mirrorLag.RemoteRepoKey, "value", mirrorLag.LagInMS)
+		e.logger.Debug(
+			"Registering metric",
+			"metric", "federationMirrorLag",
+			"repo", mirrorLag.LocalRepoKey,
+			"remote_url", mirrorLag.RemoteUrl,
+			"remote_name", mirrorLag.RemoteRepoKey,
+			"value", mirrorLag.LagInMS,
+		)
 		ch <- prometheus.MustNewConstMetric(federationMetrics["mirrorLag"], prometheus.GaugeValue, float64(mirrorLag.LagInMS), mirrorLag.LocalRepoKey, mirrorLag.RemoteUrl, mirrorLag.RemoteRepoKey, federationMirrorLags.NodeId)
 	}
 
@@ -37,12 +43,19 @@ func (e *Exporter) exportFederationUnavailableMirrors(ch chan<- prometheus.Metri
 	}
 
 	if len(federationUnavailableMirrors.UnavailableMirrors) == 0 {
-		level.Debug(e.logger).Log("msg", "No federation unavailable mirrors found")
+		e.logger.Debug("No federation unavailable mirrors found")
 		return nil
 	}
 
 	for _, unavailableMirror := range federationUnavailableMirrors.UnavailableMirrors {
-		level.Debug(e.logger).Log("msg", "Registering metric", "metric", "federationUnavailableMirror", "status", unavailableMirror.Status, "repo", unavailableMirror.LocalRepoKey, "remote_url", unavailableMirror.RemoteUrl, "remote_name", unavailableMirror.RemoteRepoKey)
+		e.logger.Debug(
+			"Registering metric",
+			"metric", "federationUnavailableMirror",
+			"status", unavailableMirror.Status,
+			"repo", unavailableMirror.LocalRepoKey,
+			"remote_url", unavailableMirror.RemoteUrl,
+			"remote_name", unavailableMirror.RemoteRepoKey,
+		)
 		ch <- prometheus.MustNewConstMetric(federationMetrics["unavailableMirror"], prometheus.GaugeValue, 1, unavailableMirror.Status, unavailableMirror.LocalRepoKey, unavailableMirror.RemoteUrl, unavailableMirror.RemoteRepoKey, federationUnavailableMirrors.NodeId)
 	}
 

--- a/collector/openMetrics.go
+++ b/collector/openMetrics.go
@@ -3,30 +3,29 @@ package collector
 import (
 	"strings"
 
-	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	ioPrometheusClient "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 )
 
 func (e *Exporter) exportOpenMetrics(ch chan<- prometheus.Metric) error {
-	// Fetch Open Metrics
 	openMetrics, err := e.client.FetchOpenMetrics()
 	if err != nil {
-		level.Error(e.logger).Log("msg", "There was an issue when try to fetch openMetrics")
+		e.logger.Error("There was an issue when try to fetch openMetrics")
 		e.totalAPIErrors.Inc()
 		return err
 	}
 
-	level.Debug(e.logger).Log("msg", "OpenMetrics from Artifactory util", "body", openMetrics.PromMetrics)
+	e.logger.Debug(
+		"OpenMetrics from Artifactory util",
+		"body", openMetrics.PromMetrics,
+	)
 
-	// assign openMetrics.Metric to a string variable
 	openMetricsString := openMetrics.PromMetrics
 
 	parser := expfmt.TextParser{}
 	metrics, err := parser.TextToMetricFamilies(strings.NewReader(openMetricsString))
 	if err != nil {
-		// handle the error
 		return err
 	}
 

--- a/collector/storage.go
+++ b/collector/storage.go
@@ -26,7 +26,7 @@ func (e *Exporter) exportCount(metricName string, metric *prometheus.Desc, count
 		return
 	}
 	e.logger.Debug(
-		"Registering metric",
+		logDbgMsgRegMetric,
 		"metric", metricName,
 		"value", value,
 	)
@@ -49,7 +49,7 @@ func (e *Exporter) exportSize(metricName string, metric *prometheus.Desc, size s
 		return
 	}
 	e.logger.Debug(
-		"Registering metric",
+		logDbgMsgRegMetric,
 		"metric", metricName,
 		"value", value,
 	)
@@ -72,7 +72,7 @@ func (e *Exporter) exportFilestore(metricName string, metric *prometheus.Desc, s
 		return
 	}
 	e.logger.Debug(
-		"Registering metric",
+		logDbgMsgRegMetric,
 		"metric", metricName,
 		"value", value,
 	)
@@ -148,7 +148,7 @@ func (e *Exporter) exportRepo(repoSummaries []repoSummary, ch chan<- prometheus.
 			switch metricName {
 			case "repoUsed":
 				e.logger.Debug(
-					"Registering metric",
+					logDbgMsgRegMetric,
 					"metric", metricName,
 					"repo", repoSummary.Name,
 					"type", repoSummary.Type,
@@ -158,7 +158,7 @@ func (e *Exporter) exportRepo(repoSummaries []repoSummary, ch chan<- prometheus.
 				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, repoSummary.UsedSpace, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
 			case "repoFolders":
 				e.logger.Debug(
-					"Registering metric",
+					logDbgMsgRegMetric,
 					"metric", metricName,
 					"repo", repoSummary.Name,
 					"type", repoSummary.Type,
@@ -168,7 +168,7 @@ func (e *Exporter) exportRepo(repoSummaries []repoSummary, ch chan<- prometheus.
 				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, repoSummary.FoldersCount, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
 			case "repoItems":
 				e.logger.Debug(
-					"Registering metric",
+					logDbgMsgRegMetric,
 					"metric", metricName,
 					"repo", repoSummary.Name,
 					"type", repoSummary.Type,
@@ -178,7 +178,7 @@ func (e *Exporter) exportRepo(repoSummaries []repoSummary, ch chan<- prometheus.
 				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, repoSummary.ItemsCount, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
 			case "repoFiles":
 				e.logger.Debug(
-					"Registering metric",
+					logDbgMsgRegMetric,
 					"metric", metricName,
 					"repo", repoSummary.Name,
 					"type", repoSummary.Type,
@@ -188,7 +188,7 @@ func (e *Exporter) exportRepo(repoSummaries []repoSummary, ch chan<- prometheus.
 				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, repoSummary.FilesCount, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
 			case "repoPercentage":
 				e.logger.Debug(
-					"Registering metric",
+					logDbgMsgRegMetric,
 					"metric", metricName,
 					"repo", repoSummary.Name,
 					"type", repoSummary.Type,

--- a/collector/system.go
+++ b/collector/system.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/peimanja/artifactory_exporter/artifactory"
@@ -13,13 +12,19 @@ import (
 func (e *Exporter) exportSystem(license artifactory.LicenseInfo, ch chan<- prometheus.Metric) error {
 	health, err := e.client.FetchHealth()
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Couldn't scrape Artifactory when fetching system/ping", "err", err)
+		e.logger.Error(
+			"Couldn't scrape Artifactory when fetching system/ping",
+			"err", err.Error(),
+		)
 		e.totalAPIErrors.Inc()
 		return err
 	}
 	buildInfo, err := e.client.FetchBuildInfo()
 	if err != nil {
-		level.Error(e.logger).Log("msg", "Couldn't scrape Artifactory when fetching system/version", "err", err)
+		e.logger.Error(
+			"Couldn't scrape Artifactory when fetching system/version",
+			"err", err.Error(),
+		)
 		e.totalAPIErrors.Inc()
 		return err
 	}
@@ -39,7 +44,10 @@ func (e *Exporter) exportSystem(license artifactory.LicenseInfo, ch chan<- prome
 				validThrough = timeNow
 			default:
 				if validThroughTime, err := time.Parse("Jan 2, 2006", license.ValidThrough); err != nil {
-					level.Warn(e.logger).Log("msg", "Couldn't parse Artifactory license ValidThrough", "err", err)
+					e.logger.Warn(
+						"Couldn't parse Artifactory license ValidThrough",
+						"err", err.Error(),
+					)
 					validThrough = timeNow
 				} else {
 					validThrough = float64(validThroughTime.Unix())

--- a/collector/utils.go
+++ b/collector/utils.go
@@ -5,51 +5,79 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-
-	"github.com/go-kit/log/level"
 )
 
+const (
+	mulKB = 1024
+	mulMB = mulKB * 1024
+	mulGB = mulMB * 1024
+	mulTB = mulGB * 1024
+)
+
+// A one-time regex compilation is far cheaper
+// than repeating on each function entry.
+// `MustCompile` is used because regex value is hardcoded
+// i.e. may have been previously verified by the author.
+var regNumber = regexp.MustCompile("[^0-9.]+")
+
 func (e *Exporter) removeCommas(str string) (float64, error) {
-	level.Debug(e.logger).Log("msg", "Removing other characters to extract number from string")
-	reg, err := regexp.Compile("[^0-9.]+")
-	if err != nil {
-		return 0, err
-	}
+	e.logger.Debug("Removing other characters to extract number from string")
+	/*
+	 * I am very concerned about the “magic” used here.
+	 * The code does not in any way explain why this particular
+	 * method of extracting content from the text was adopted.
+	 * Kacper Perschke
+	 */
 	strArray := strings.Fields(str)
-	strTrimmed := reg.ReplaceAllString(strArray[0], "")
-	convertedStr, err := strconv.ParseFloat(strTrimmed, 64)
+	strTrimmed := regNumber.ReplaceAllString(strArray[0], "")
+	num, err := strconv.ParseFloat(strTrimmed, 64)
 	if err != nil {
+		e.logger.Debug(
+			"Had problem extracting number",
+			"string", str,
+			"err", err.Error(),
+		)
 		return 0, err
 	}
-	level.Debug(e.logger).Log("msg", "Successfully converted string to number", "string", str, "number", convertedStr)
-	return convertedStr, nil
+	e.logger.Debug(
+		"Successfully converted string to number",
+		"string", str,
+		"number", num,
+	)
+	return num, nil
 }
 
 func (e *Exporter) bytesConverter(str string) (float64, error) {
-	var bytesValue float64
-	level.Debug(e.logger).Log("msg", "Converting size to bytes")
+	e.logger.Debug("Converting size to bytes")
 	num, err := e.removeCommas(str)
 	if err != nil {
 		return 0, err
 	}
-
+	var bytesValue float64
 	if strings.Contains(str, "bytes") {
 		bytesValue = num
 	} else if strings.Contains(str, "KB") {
-		bytesValue = num * 1024
+		bytesValue = num * mulKB
 	} else if strings.Contains(str, "MB") {
-		bytesValue = num * 1024 * 1024
+		bytesValue = num * mulMB
 	} else if strings.Contains(str, "GB") {
-		bytesValue = num * 1024 * 1024 * 1024
+		bytesValue = num * mulGB
 	} else if strings.Contains(str, "TB") {
-		bytesValue = num * 1024 * 1024 * 1024 * 1024
+		bytesValue = num * mulTB
 	} else {
 		return 0, fmt.Errorf("Could not convert %s to bytes", str)
 	}
-	level.Debug(e.logger).Log("msg", "Successfully converted string to bytes", "string", str, "value", bytesValue)
+	e.logger.Debug(
+		"Successfully converted string to bytes",
+		"string", str,
+		"value", bytesValue,
+	)
 	return bytesValue, nil
 }
 
+// b2f is a very interesting appendix.
+// Something needs it, but what and why?
+// It would be quite nice if it was written here why such a thing is needed.
 func b2f(b bool) float64 {
 	if b {
 		return 1

--- a/go.mod
+++ b/go.mod
@@ -18,11 +18,9 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.0 // indirect
 	github.com/golang/protobuf v1.4.3 // indirect
-	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
-	github.com/sirupsen/logrus v1.6.0 // indirect
 	golang.org/x/sys v0.2.0 // indirect
 	google.golang.org/protobuf v1.26.0-rc.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/peimanja/artifactory_exporter
 
-go 1.18
+go 1.21
 
 require (
 	github.com/go-kit/log v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -53,7 +53,6 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -93,7 +92,6 @@ github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3x
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/logger/config.go
+++ b/logger/config.go
@@ -1,0 +1,46 @@
+package logger
+
+import "log/slog"
+
+type Config struct {
+	Format string
+	Level  string
+}
+
+const (
+	FormatDefault  = fmtTXT
+	FormatFlagHelp = "Output format of log messages. One of: [logfmt, json]"
+	FormatFlagName = "log.format"
+	fmtJSON        = "json"
+	fmtTXT         = "logfmt"
+)
+const (
+	lvlFNameDebug = "debug"
+	lvlFNameInfo  = "info"
+	lvlFNameWarn  = "warn"
+	lvlFNameError = "error"
+	LevelDefault  = lvlFNameInfo
+	LevelFlagHelp = "Only log messages with the given severity or above. One of: [debug, info, warn, error]"
+	LevelFlagName = "log.level"
+)
+
+var (
+	EmptyConfig      = Config{}
+	FormatsAvailable = []string{
+		fmtTXT,
+		fmtJSON,
+	}
+	LevelsAvailable = []string{
+		// Deliberately not in alphabetical order, but according to the significance of the levels.
+		lvlFNameDebug,
+		lvlFNameInfo,
+		lvlFNameWarn,
+		lvlFNameError,
+	}
+	levelsFlagToSlog = map[string]slog.Level{
+		"debug": slog.LevelDebug,
+		"info":  slog.LevelInfo,
+		"warn":  slog.LevelWarn,
+		"error": slog.LevelError,
+	}
+)

--- a/logger/doc.go
+++ b/logger/doc.go
@@ -1,0 +1,9 @@
+// Package logger wraps configuration of `log/slog`.
+//
+// It is used by "github.com/peimanja/artifactory_exporter/config"
+// and is not expected to be used outside the artifactory exporter.
+//
+// To maintain backward compatibility, log to os.Stderr
+// as already used "github.com/prometheus/common/promlog".
+
+package logger

--- a/logger/slog.go
+++ b/logger/slog.go
@@ -1,0 +1,68 @@
+package logger
+
+import (
+	"log/slog"
+	"os"
+)
+
+// New returns configured instance of `log/slog`
+//
+// Expects configuration in the Config type structure.
+// In the absence of appropriate information in the provided configuration,
+// values `FormatDefault` or `LevelDefault` will be assumed.
+func New(c Config) *slog.Logger {
+
+	lvl := lvlFromConfig(c)
+
+	switch lf := fmtFromConfig(c); lf {
+	case fmtTXT:
+		return newTXTLogger(lvl)
+	case fmtJSON:
+		return newJSONLogger(lvl)
+	default:
+		l := newTXTLogger(lvl)
+		l.Error("We should never have ended up here! Plase report an issue")
+		os.Exit(1)
+	}
+
+	/*
+	 * The following should never happen and is only there
+	 * to satisfy the compiler's formal requirements.
+	 */
+	return newTXTLogger(lvl)
+}
+
+func fmtFromConfig(c Config) string {
+	if c.Format != "" {
+		return c.Format
+	}
+	return FormatDefault
+}
+
+func lvlFromConfig(c Config) slog.Level {
+	lvlFromFlag := LevelDefault
+	if c.Level != "" {
+		lvlFromFlag = c.Level
+	}
+	return levelsFlagToSlog[lvlFromFlag]
+}
+
+func newJSONLogger(l slog.Level) *slog.Logger {
+	h := slog.NewJSONHandler(
+		os.Stderr, // Please read the explanation in the `doc.go` file.
+		&slog.HandlerOptions{
+			Level: l,
+		},
+	)
+	return slog.New(h)
+}
+
+func newTXTLogger(l slog.Level) *slog.Logger {
+	h := slog.NewTextHandler(
+		os.Stderr, // Please read the explanation in the `doc.go` file.
+		&slog.HandlerOptions{
+			Level: l,
+		},
+	)
+	return slog.New(h)
+}


### PR DESCRIPTION
Logger `github.com/prometheus/common/log` is [already marked as obsolete in version v0.26.0](https://github.com/prometheus/common/blob/v0.26.0/log/log.go#L16).

The `log/slog` component is new to the go standard library. It feels light and fast.

Hopefully we could then use it to choke out the `github.com/go-kit/log` library.