### PR TITLE
Attempt to solve report no. 127

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,14 @@ ARG SOURCE_BRANCH
 ARG BUILD_DATE
 ARG BUILD_USER
 
-RUN GOOS=linux GOARCH=amd64 go build -o /go/bin/artifactory_exporter -ldflags " \
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /go/bin/artifactory_exporter -ldflags " \
     -X github.com/prometheus/common/version.Version=${VERSION} \
     -X github.com/prometheus/common/version.Revision=${SOURCE_COMMIT} \
     -X github.com/prometheus/common/version.Branch=${SOURCE_BRANCH} \
     -X github.com/prometheus/common/version.BuildDate=${BUILD_DATE} \
     -X github.com/prometheus/common/version.BuildUser=${BUILD_USER}"
 
-FROM gcr.io/distroless/base-debian11
+FROM alpine:3.19.0
 COPY --from=build /go/bin/artifactory_exporter /
 
 USER   nobody

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM golang:1.21 as build
 WORKDIR /go/artifactory_exporter
 ADD . /go/artifactory_exporter
 
-RUN go get -d -v ./...
-
 ARG VERSION
 ARG SOURCE_COMMIT
 ARG SOURCE_BRANCH
@@ -18,10 +16,10 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /go/bin/artifactory_export
     -X github.com/prometheus/common/version.BuildDate=${BUILD_DATE} \
     -X github.com/prometheus/common/version.BuildUser=${BUILD_USER}"
 
-FROM alpine:3.19.0
+FROM alpine:3.19
 COPY --from=build /go/bin/artifactory_exporter /
 
 USER   nobody
 EXPOSE 9531
 
-ENTRYPOINT ["./artifactory_exporter"]
+ENTRYPOINT ["/artifactory_exporter"]


### PR DESCRIPTION
### Reason
I do hope that it resolves #127 .
### Kind of proof
```
(Issue_127 $)$ docker build -t katz_heavy -f Dockerfile .
⋮
Successfully built ab19757da3f7
Successfully tagged katz_heavy:latest
(Issue_127 $)$ docker run --rm katz_heavy -h
usage: artifactory_exporter [<flags>]

Flags:
  -h, --help                    Show context-sensitive help (also try
                                --help-long and --help-man).
      --log.format=logfmt       Output format of log messages. One of: [logfmt,
                                json]
      --log.level=info          Only log messages with the given severity or
                                above. One of: [debug, info, warn, error]
      --web.listen-address=":9531"  
                                Address to listen on for web interface and
                                telemetry.
      --web.telemetry-path="/metrics"  
                                Path under which to expose metrics.
      --artifactory.scrape-uri="http://localhost:8081/artifactory"  
                                URI on which to scrape JFrog Artifactory.
      --artifactory.ssl-verify  Flag that enables SSL certificate verification
                                for the scrape URI
      --artifactory.timeout=5s  Timeout for trying to get stats from JFrog
                                Artifactory.
      --optional-metric=metric-name ...  
                                optional metric to be enabled. Pass multiple
                                times to enable multiple optional metrics.
      --version                 Show application version.
```