### PR TITLE
Don't panic if FetchReplications gets a url.Error

### DIFF
--- a/artifactory/replication.go
+++ b/artifactory/replication.go
@@ -2,6 +2,7 @@ package artifactory
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -39,7 +40,8 @@ func (c *Client) FetchReplications() (Replications, error) {
 	c.logger.Debug("Fetching replications stats")
 	resp, err := c.FetchHTTP(replicationEndpoint)
 	if err != nil {
-		if err.(*APIError).status == 404 {
+		var apiErr *APIError
+		if errors.As(err, &apiErr) && apiErr.status == 404 {
 			return replications, nil
 		}
 		return replications, err


### PR DESCRIPTION
If FetchHTTP() suffers a lower-level error, it will return an err that *is not* an instance of APIError. In such cases, the daemon currently panics, which isn't a great response. Instead, it should properly handle the error up the stack and retry later.

    ts=2024-05-21T19:45:05.943Z caller=log.go:124 level=debug msg="Fetching http" path=http://localhost:8081/artifactory/api/system/license
    panic: interface conversion: error is *url.Error, not *artifactory.APIError
    goroutine 886625 [running]:
    github.com/peimanja/artifactory_exporter/artifactory.(*Client).FetchReplications(0xc00022c080)
    /go/artifactory_exporter/artifactory/replication.go:44 +0xa5f
    github.com/peimanja/artifactory_exporter/collector.(*Exporter).exportReplications(0xc00022c100, 0x912cc1?)
    /go/artifactory_exporter/collector/replication.go:12 +0x45
    github.com/peimanja/artifactory_exporter/collector.(*Exporter).scrape(0xc00022c100, 0xc00055a720?)
    /go/artifactory_exporter/collector/collector.go:151 +0x5a6
    github.com/peimanja/artifactory_exporter/collector.(*Exporter).Collect(0xc00022c100, 0xc000478f60?)
    /go/artifactory_exporter/collector/collector.go:115 +0x85
    github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
    /go/pkg/mod/github.com/prometheus/client_golang@v1.11.1/prometheus/registry.go:446 +0xfb
    created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather
    /go/pkg/mod/github.com/prometheus/client_golang@v1.11.1/prometheus/registry.go:538 +0xb0b