### PR TITLE
convArtiToPromNumber use case

### DIFF
--- a/collector/converter.go
+++ b/collector/converter.go
@@ -21,7 +21,7 @@ func convArtiToPromBool(b bool) float64 {
 }
 
 const (
-	pattNumber = `^(?P<number>[[:digit:]]{1,3}(?:,[[:digit:]]{3})*(?:\.[[:digit:]]{1,2})?) ?(?P<multiplier>%|bytes|[KMGT]B)?$`
+	pattNumber = `^(?P<number>[[:digit:]]{1,4}(?:,[[:digit:]]{3})*(?:\.[[:digit:]]{1,2})?) ?(?P<multiplier>%|bytes|[KMGT]B)?$`
 )
 
 var (

--- a/collector/converter_test.go
+++ b/collector/converter_test.go
@@ -64,6 +64,11 @@ func TestConvNum(t *testing.T) {
 			input: `100 %`,
 			want:  1.0,
 		},
+		{
+			// Detected during testing of https://github.com/peimanja/artifactory_exporter/pull/149
+			input: `1000GB`,
+			want:  1073741824000.0,
+		},
 	}
 	for _, tc := range tests {
 		got, err := fakeExporter.convArtiToPromNumber(tc.input)


### PR DESCRIPTION
The regular expression `pattNumber` did not recognise the word `1000GB`.

This was detected when test running the application with the ‘#149’ commits applied.

The solution is not fully immune to passing errors. For example, it will let through the `1000,999KB` text. But I do not want to complicate the regualr expression `pattNumber`.

**Please address this very much before #149.**