### PR TITLE
Little proffing of convArtiToPromNumber.

### DIFF
--- a/collector/converter.go
+++ b/collector/converter.go
@@ -21,7 +21,7 @@ func convArtiToPromBool(b bool) float64 {
 }
 
 const (
-	pattNumber = `^(?P<number>[[:digit:]]{1,4}(?:,[[:digit:]]{3})*(?:\.[[:digit:]]{1,2})?) ?(?P<multiplier>%|bytes|[KMGT]B)?$`
+	pattNumber = `^(?P<number>[[:digit:]]{1,3}(?:[[:digit:]]|(?:,[[:digit:]]{3})*(?:\.[[:digit:]]{1,2}))?) ?(?P<multiplier>%|bytes|[KMGT]B)?$`
 )
 
 var (
@@ -40,10 +40,11 @@ func (e *Exporter) convArtiToPromNumber(artiNum string) (float64, error) {
 			logDbgKeyArtNum, artiNum,
 		)
 		err := fmt.Errorf(
-			`The string '%s' does not match pattern '%s'.`,
+			`the string '%s' does not match pattern '%s'.`,
 			artiNum,
 			pattNumber,
 		)
+
 		return 0, err
 	}
 

--- a/collector/converter_test.go
+++ b/collector/converter_test.go
@@ -69,6 +69,11 @@ func TestConvNum(t *testing.T) {
 			input: `1000GB`,
 			want:  1073741824000.0,
 		},
+		{
+			// https://github.com/peimanja/artifactory_exporter/pull/150#pullrequestreview-2422219410
+			input: `9999 KB`,
+			want:  10238976.0,
+		},
 	}
 	for _, tc := range tests {
 		got, err := fakeExporter.convArtiToPromNumber(tc.input)


### PR DESCRIPTION
As Peiman wrote in [his comment](https://github.com/peimanja/artifactory_exporter/pull/150#pullrequestreview-2422219410) to #150.

I went towards smart regular expression and a one-step algorithm.

I am still not proficient enough to show in tests that for the cases
- `1000,999KB`
- `1000,999 KB`
- `12345`

the function would report the relevant errors. _This is a pity_.