### PR TITLE
Add metric to monitor all licenses in a HA setup

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -51,9 +51,10 @@ var (
 	}
 
 	systemMetrics = metrics{
-		"healthy": newMetric("healthy", "system", "Is Artifactory working properly (1 = healthy).", defaultLabelNames),
-		"version": newMetric("version", "system", "Version and revision of Artifactory as labels.", append([]string{"version", "revision"}, defaultLabelNames...)),
-		"license": newMetric("license", "system", "License type and expiry as labels, seconds to expiration as value", append([]string{"type", "licensed_to", "expires"}, defaultLabelNames...)),
+		"healthy":  newMetric("healthy", "system", "Is Artifactory working properly (1 = healthy).", defaultLabelNames),
+		"version":  newMetric("version", "system", "Version and revision of Artifactory as labels.", append([]string{"version", "revision"}, defaultLabelNames...)),
+		"license":  newMetric("license", "system", "License type and expiry as labels, seconds to expiration as value", append([]string{"type", "licensed_to", "expires"}, defaultLabelNames...)),
+		"licenses": newMetric("licenses", "system", "License type and expiry as labels, seconds to expiration as value", append([]string{"type", "valid_through", "licensed_to", "node_url", "license_hash", "expires"}, defaultLabelNames...)),
 	}
 
 	artifactsMetrics = metrics{
@@ -145,6 +146,11 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) (up float64) {
 		return 0
 	}
 
+	// Collect and export system HA licenses metrics
+	if err := e.exportSystemHALicenses(ch); err != nil {
+		return 0
+	}
+	
 	// Fetch Storage Info stats and register them
 	storageInfo, err := e.client.FetchStorageInfo()
 	if err != nil {

--- a/collector/system.go
+++ b/collector/system.go
@@ -1,6 +1,8 @@
 package collector
 
 import (
+	"strconv"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -81,7 +83,7 @@ func (e *Exporter) exportSystem(ch chan<- prometheus.Metric) error {
 }
 
 func (e *Exporter) exportSystemHALicenses(ch chan<- prometheus.Metric) error {
-	licenses, err := e.client.FetchLicenses()
+	licensesInfo, err := e.client.FetchLicenses()
 	if err != nil {
 		e.logger.Error(
 			"Couldn't scrape Artifactory when fetching system/licenses",
@@ -107,9 +109,9 @@ func (e *Exporter) exportSystemHALicenses(ch chan<- prometheus.Metric) error {
 			licenseInfo.TypeNormalized(),
 			licenseInfo.ValidThrough,
 			licenseInfo.LicensedTo,
-			license.NodeUrl,
-			license.LicenseHash,
-			strconv.FormatBool(license.Expired),
+			licenseInfo.NodeUrl,
+			licenseInfo.LicenseHash,
+			strconv.FormatBool(licenseInfo.Expired),
 			licenseInfo.NodeId,
 		)
 	}


### PR DESCRIPTION
When Artifactory is deployed in a [high availability (HA) setup](https://jfrog.com/help/r/jfrog-installation-setup-documentation/high-availability), each replica consumes one license. These multiple licenses might have varying expiration dates and monitoring these is important to know when to renew each.

Currently, Artifactory exporter monitors the [`/license`](https://jfrog.com/help/r/jfrog-rest-apis/license-information) endpoint, which always returns a single license, even in a HA setup.

This pull request adds the functionality to monitor the [`/licenses`](https://jfrog.com/help/r/jfrog-rest-apis/ha-license-information) endpoint as well with an additional metric.

This new metric is called `licenses` and has the following fields based on the API response: `"type", "valid_through", "licensed_to", "node_url", "license_hash", "expires", "node_id"`.