### PR TITLE
Add metric to monitor JFrog Access Federation validation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Supported optional metrics:
 * `replication_status` - Extracts status of replication for each repository which has replication enabled. Enabling this will add the `status` label to `artifactory_replication_enabled` metric.
 * `federation_status` - Extracts federation metrics. Enabling this will add two new metrics: `artifactory_federation_mirror_lag`, and `artifactory_federation_unavailable_mirror`. Please note that these metrics are only available in Artifactory Enterprise Plus and version 7.18.3 and above.
 * `open_metrics` - Exposes Open Metrics from the JFrog Platform. For more information about Open Metrics, please refer to [JFrog Platform Open Metrics](https://jfrog.com/help/r/jfrog-platform-administration-documentation/open-metrics).
+* `access_federation_validate` - Validates whether trust is established towards a given JFrog Access Federation target server. Requires optional parameter `access-federation-target` to be set to the URL of the target server as well as token-based authentication. For more information, please refer to [JFrog Access Federation Circle of Trust validation](https://jfrog.com/help/r/jfrog-rest-apis/validate-target-for-circle-of-trust).
 
 ### Grafana Dashboard
 

--- a/artifactory/access.go
+++ b/artifactory/access.go
@@ -1,0 +1,49 @@
+package artifactory
+
+import (
+	"encoding/json"
+)
+
+const (
+	accessFederationValidateEndpoint = "access/api/v1/system/federation/validate_server"
+)
+
+type AccessFederationValid struct {
+	Status bool
+	NodeId string
+}
+
+// FetchAccessFederationValidStatus checks one of the federation endpoints to see if federation is enabled
+func (c *Client) FetchAccessFederationValidStatus() (AccessFederationValid, error) {
+	accessFederationValid := AccessFederationValid{Status: false}
+
+	// Use ping endpoint to retrieve nodeID, since this is not returned by access API
+	resp, err := c.FetchHTTP(pingEndpoint)
+	if err != nil {
+		return accessFederationValid, err
+	}
+	accessFederationValid.NodeId = resp.NodeId
+
+	jsonBody := map[string]string{
+		"url": c.accessFederationTarget,
+	}
+	jsonBytes, err := json.Marshal(jsonBody)
+	if err != nil {
+		c.logger.Error("issue when trying to marshal JSON body")
+		return accessFederationValid, err
+	}
+	headers := map[string]string{
+		"Content-Type": "application/json",
+	}
+	c.logger.Debug(
+		"Fetching JFrog Access Federation validation status",
+		"endpoint", accessFederationValidateEndpoint,
+		"target", c.accessFederationTarget,
+	)
+	_, err = c.PostHTTP(accessFederationValidateEndpoint, jsonBytes, &headers)
+	if err != nil {
+		return accessFederationValid, err
+	}
+	accessFederationValid.Status = true
+	return accessFederationValid, nil
+}

--- a/artifactory/client.go
+++ b/artifactory/client.go
@@ -10,12 +10,13 @@ import (
 
 // Client represents Artifactory HTTP Client
 type Client struct {
-	URI             string
-	authMethod      string
-	cred            config.Credentials
-	optionalMetrics config.OptionalMetrics
-	client          *http.Client
-	logger          *slog.Logger
+	URI                    string
+	authMethod             string
+	cred                   config.Credentials
+	optionalMetrics        config.OptionalMetrics
+	accessFederationTarget string
+	client                 *http.Client
+	logger                 *slog.Logger
 }
 
 // NewClient returns an initialized Artifactory HTTP Client.
@@ -26,11 +27,16 @@ func NewClient(conf *config.Config) *Client {
 		Transport: tr,
 	}
 	return &Client{
-		URI:             conf.ArtiScrapeURI,
-		authMethod:      conf.Credentials.AuthMethod,
-		cred:            *conf.Credentials,
-		optionalMetrics: conf.OptionalMetrics,
-		client:          client,
-		logger:          conf.Logger,
+		URI:                    conf.ArtiScrapeURI,
+		authMethod:             conf.Credentials.AuthMethod,
+		cred:                   *conf.Credentials,
+		optionalMetrics:        conf.OptionalMetrics,
+		accessFederationTarget: conf.AccessFederationTarget,
+		client:                 client,
+		logger:                 conf.Logger,
 	}
+}
+
+func (c *Client) GetAccessFederationTarget() string {
+	return c.accessFederationTarget
 }

--- a/artifactory/utils.go
+++ b/artifactory/utils.go
@@ -66,35 +66,62 @@ func (c *Client) makeRequest(method string, path string, body []byte, headers **
 	return c.client.Do(req)
 }
 
-func (c *Client) procRespErr(resp *http.Response, fPath string) (*ApiResponse, error) {
+func (c *Client) handleResponse(resp *http.Response, fullPath string) (*ApiResponse, error) {
 	var apiErrors APIErrors
-	bodyBytes, _ := ioutil.ReadAll(resp.Body)
-	if err := json.Unmarshal(bodyBytes, &apiErrors); err != nil {
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
 		c.logger.Error(
-			logMsgErrUnmarshall,
-			"err", err.Error(),
+			logMsgErrRespBody,
+			"err", err,
 		)
-		return nil, &UnmarshalError{
-			message:  err.Error(),
-			endpoint: fPath,
+		return nil, err
+	}
+	if !slices.Contains(httpSuccCodes, resp.StatusCode) {
+		if err := json.Unmarshal(bodyBytes, &apiErrors); err != nil {
+			c.logger.Error(
+				logMsgErrUnmarshall,
+				"err", err.Error(),
+			)
+			return nil, &UnmarshalError{
+				message:  err.Error(),
+				endpoint: fullPath,
+			}
+		}
+		if resp.StatusCode == http.StatusNotFound {
+			c.logger.Warn(
+				"The endpoint does not exist",
+				"endpoint", fullPath,
+				"err", fmt.Sprintf("%v", apiErrors.Errors),
+				"status", http.StatusNotFound,
+			)
+			return nil, &APIError{
+				message:  fmt.Sprintf("%v", apiErrors.Errors),
+				endpoint: fullPath,
+				status:   http.StatusNotFound,
+			}
+		}
+		c.logger.Error(
+			logMsgErrAPICall,
+			"endpoint", fullPath,
+			"err", fmt.Sprintf("%v", apiErrors.Errors),
+			"status", resp.StatusCode,
+		)
+		return nil, &APIError{
+			message:  fmt.Sprintf("%v", apiErrors.Errors),
+			endpoint: fullPath,
+			// status:   resp.StatusCode, // Maybe it would be worth returning it too? As with http.StatusNotFound.
 		}
 	}
-	c.logger.Error(
-		logMsgErrAPICall,
-		"endpoint", fPath,
-		"err", fmt.Sprintf("%v", apiErrors.Errors),
-		"status", resp.StatusCode,
-	)
-	return nil, &APIError{
-		message:  fmt.Sprintf("%v", apiErrors.Errors),
-		endpoint: fPath,
-		// status:   resp.StatusCode, // Maybe it would be worth returning it too? As with http.StatusNotFound.
+
+	response := &ApiResponse{
+		Body:   bodyBytes,
+		NodeId: resp.Header.Get("x-artifactory-node-id"),
 	}
+	return response, nil
 }
 
 // FetchHTTP is a wrapper function for making all Get API calls
 func (c *Client) FetchHTTP(path string) (*ApiResponse, error) {
-	var response ApiResponse
 	fullPath := fmt.Sprintf("%s/api/%s", c.URI, path)
 	c.logger.Debug(
 		"Fetching http",
@@ -109,55 +136,12 @@ func (c *Client) FetchHTTP(path string) (*ApiResponse, error) {
 		)
 		return nil, err
 	}
-	response.NodeId = resp.Header.Get("x-artifactory-node-id")
 	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		var apiErrors APIErrors
-		bodyBytes, _ := ioutil.ReadAll(resp.Body)
-		if err := json.Unmarshal(bodyBytes, &apiErrors); err != nil {
-			c.logger.Error(
-				logMsgErrUnmarshall,
-				"err", err,
-			)
-			return nil, &UnmarshalError{
-				message:  err.Error(),
-				endpoint: fullPath,
-			}
-		}
-		c.logger.Warn(
-			"The endpoint does not exist",
-			"endpoint", fullPath,
-			"err", fmt.Sprintf("%v", apiErrors.Errors),
-			"status", http.StatusNotFound,
-		)
-		return nil, &APIError{
-			message:  fmt.Sprintf("%v", apiErrors.Errors),
-			endpoint: fullPath,
-			status:   http.StatusNotFound,
-		}
-	}
-
-	if !slices.Contains(httpSuccCodes, resp.StatusCode) {
-		return c.procRespErr(resp, fullPath)
-	}
-
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		c.logger.Error(
-			logMsgErrRespBody,
-			"err", err.Error(),
-		)
-		return nil, err
-	}
-	response.Body = bodyBytes
-
-	return &response, nil
+	return c.handleResponse(resp, fullPath)
 }
 
 // QueryAQL is a wrapper function for making an query to AQL endpoint
 func (c *Client) QueryAQL(query []byte) (*ApiResponse, error) {
-	var response ApiResponse
 	fullPath := fmt.Sprintf("%s/api/search/aql", c.URI)
 	c.logger.Debug(
 		"Running AQL query",
@@ -172,42 +156,20 @@ func (c *Client) QueryAQL(query []byte) (*ApiResponse, error) {
 		)
 		return nil, err
 	}
-	response.NodeId = resp.Header.Get("x-artifactory-node-id")
 	defer resp.Body.Close()
-	if !slices.Contains(httpSuccCodes, resp.StatusCode) {
-		return c.procRespErr(resp, fullPath)
-	}
-
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		c.logger.Error(
-			logMsgErrRespBody,
-			"err", err.Error(),
-		)
-		return nil, err
-	}
-	response.Body = bodyBytes
-	return &response, nil
+	return c.handleResponse(resp, fullPath)
 }
 
 // PostHTTP is a wrapper function for making all Post API calls
 // Note: the API endpoint (e.g. "/artifactory" or "/access") needs to be part of path
 func (c *Client) PostHTTP(path string, body []byte, headers *map[string]string) (*ApiResponse, error) {
-	var response ApiResponse
-
 	artifactoryURI := strings.TrimSuffix(c.URI, "/artifactory")
 	fullPath := fmt.Sprintf("%s/%s", artifactoryURI, path)
-
 	c.logger.Debug(
 		"Posting http",
 		"path", fullPath,
 	)
-
 	resp, err := c.makeRequest("POST", fullPath, body, &headers)
-	c.logger.Debug(
-		"Received response with",
-		"status", resp.StatusCode,
-	)
 	if err != nil {
 		c.logger.Error(
 			logMsgErrAPICall,
@@ -217,46 +179,5 @@ func (c *Client) PostHTTP(path string, body []byte, headers *map[string]string) 
 		return nil, err
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		var apiErrors APIErrors
-		bodyBytes, _ := ioutil.ReadAll(resp.Body)
-		if err := json.Unmarshal(bodyBytes, &apiErrors); err != nil {
-			c.logger.Error(
-				logMsgErrUnmarshall,
-				"err", err,
-			)
-			return nil, &UnmarshalError{
-				message:  err.Error(),
-				endpoint: fullPath,
-			}
-		}
-		c.logger.Warn(
-			"The endpoint does not exist",
-			"endpoint", fullPath,
-			"err", fmt.Sprintf("%v", apiErrors.Errors),
-			"status", http.StatusNotFound,
-		)
-		return nil, &APIError{
-			message:  fmt.Sprintf("%v", apiErrors.Errors),
-			endpoint: fullPath,
-			status:   http.StatusNotFound,
-		}
-	}
-
-	if !slices.Contains(httpSuccCodes, resp.StatusCode) {
-		return c.procRespErr(resp, fullPath)
-	}
-
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		c.logger.Error(
-			logMsgErrRespBody,
-			"err", err.Error(),
-		)
-		return nil, err
-	}
-	response.Body = bodyBytes
-
-	return &response, nil
+	return c.handleResponse(resp, fullPath)
 }

--- a/artifactory/utils.go
+++ b/artifactory/utils.go
@@ -13,6 +13,7 @@ import (
 const (
 	logMsgErrAPICall    = "There was an error making API call"
 	logMsgErrUnmarshall = "There was an error when trying to unmarshal the API Error"
+	logMsgErrRespBody   = "There was an error reading response body"
 )
 
 // APIErrors represents Artifactory API Error response
@@ -144,7 +145,7 @@ func (c *Client) FetchHTTP(path string) (*ApiResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		c.logger.Error(
-			"There was an error reading response body",
+			logMsgErrRespBody,
 			"err", err.Error(),
 		)
 		return nil, err
@@ -180,7 +181,7 @@ func (c *Client) QueryAQL(query []byte) (*ApiResponse, error) {
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		c.logger.Error(
-			"There was an error reading response body",
+			logMsgErrRespBody,
 			"err", err.Error(),
 		)
 		return nil, err
@@ -250,7 +251,7 @@ func (c *Client) PostHTTP(path string, body []byte, headers *map[string]string) 
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		c.logger.Error(
-			"There was an error reading response body",
+			logMsgErrRespBody,
 			"err", err.Error(),
 		)
 		return nil, err

--- a/collector/access.go
+++ b/collector/access.go
@@ -1,0 +1,27 @@
+package collector
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func (e *Exporter) exportAccessFederationValidate(ch chan<- prometheus.Metric) error {
+	// Fetch Federation Mirror Lags
+	accessFederationValid, err := e.client.FetchAccessFederationValidStatus()
+	if err != nil {
+		e.logger.Warn(
+			"JFrog Access Federation Circle of Trust was not successfully validated",
+			"target", e.client.GetAccessFederationTarget(),
+			"status", accessFederationValid.Status,
+			"err", err.Error(),
+		)
+		e.totalAPIErrors.Inc()
+	}
+	value := convArtiToPromBool(accessFederationValid.Status)
+	e.logger.Debug(
+		logDbgMsgRegMetric,
+		"metric", "accessFederationValid",
+		"value", value,
+	)
+	ch <- prometheus.MustNewConstMetric(accessMetrics["accessFederationValid"], prometheus.GaugeValue, value, accessFederationValid.NodeId)
+	return nil
+}

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -72,6 +72,9 @@ var (
 	openMetrics = metrics{
 		"openMetrics": newMetric("open_metrics", "openmetrics", "OpenMetrics proxied from JFrog Platform", defaultLabelNames),
 	}
+	accessMetrics = metrics{
+		"accessFederationValid": newMetric("access_federation_valid", "access", "Is JFrog Access Federation valid (1 = Circle of Trust validated)", defaultLabelNames),
+	}
 )
 
 func init() {
@@ -105,6 +108,11 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	}
 	if e.optionalMetrics.OpenMetrics {
 		for _, m := range openMetrics {
+			ch <- m
+		}
+	}
+	if e.optionalMetrics.AccessFederationValidate {
+		for _, m := range accessMetrics {
 			ch <- m
 		}
 	}
@@ -179,6 +187,11 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) (up float64) {
 	if e.optionalMetrics.FederationStatus && e.client.IsFederationEnabled() {
 		e.exportFederationMirrorLags(ch)
 		e.exportFederationUnavailableMirrors(ch)
+	}
+
+	// Get Access Federation Validation metric
+	if e.optionalMetrics.AccessFederationValidate {
+		e.exportAccessFederationValidate(ch)
 	}
 
 	return 1

--- a/config/config.go
+++ b/config/config.go
@@ -14,14 +14,15 @@ import (
 )
 
 var (
-	flagLogFormat   = kingpin.Flag(l.FormatFlagName, l.FormatFlagHelp).Default(l.FormatDefault).Enum(l.FormatsAvailable...)
-	flagLogLevel    = kingpin.Flag(l.LevelFlagName, l.LevelFlagHelp).Default(l.LevelDefault).Enum(l.LevelsAvailable...)
-	listenAddress   = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Envar("WEB_LISTEN_ADDR").Default(":9531").String()
-	metricsPath     = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Envar("WEB_TELEMETRY_PATH").Default("/metrics").String()
-	artiScrapeURI   = kingpin.Flag("artifactory.scrape-uri", "URI on which to scrape JFrog Artifactory.").Envar("ARTI_SCRAPE_URI").Default("http://localhost:8081/artifactory").String()
-	artiSSLVerify   = kingpin.Flag("artifactory.ssl-verify", "Flag that enables SSL certificate verification for the scrape URI").Envar("ARTI_SSL_VERIFY").Default("false").Bool()
-	artiTimeout     = kingpin.Flag("artifactory.timeout", "Timeout for trying to get stats from JFrog Artifactory.").Envar("ARTI_TIMEOUT").Default("5s").Duration()
-	optionalMetrics = kingpin.Flag("optional-metric", "optional metric to be enabled. Pass multiple times to enable multiple optional metrics.").PlaceHolder("metric-name").Strings()
+	flagLogFormat          = kingpin.Flag(l.FormatFlagName, l.FormatFlagHelp).Default(l.FormatDefault).Enum(l.FormatsAvailable...)
+	flagLogLevel           = kingpin.Flag(l.LevelFlagName, l.LevelFlagHelp).Default(l.LevelDefault).Enum(l.LevelsAvailable...)
+	listenAddress          = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Envar("WEB_LISTEN_ADDR").Default(":9531").String()
+	metricsPath            = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Envar("WEB_TELEMETRY_PATH").Default("/metrics").String()
+	artiScrapeURI          = kingpin.Flag("artifactory.scrape-uri", "URI on which to scrape JFrog Artifactory.").Envar("ARTI_SCRAPE_URI").Default("http://localhost:8081/artifactory").String()
+	artiSSLVerify          = kingpin.Flag("artifactory.ssl-verify", "Flag that enables SSL certificate verification for the scrape URI").Envar("ARTI_SSL_VERIFY").Default("false").Bool()
+	artiTimeout            = kingpin.Flag("artifactory.timeout", "Timeout for trying to get stats from JFrog Artifactory.").Envar("ARTI_TIMEOUT").Default("5s").Duration()
+	optionalMetrics        = kingpin.Flag("optional-metric", "optional metric to be enabled. Pass multiple times to enable multiple optional metrics.").PlaceHolder("metric-name").Strings()
+	accessFederationTarget = kingpin.Flag("access-federation-target", "URL of Jfrog Access Federation Target server. Only required if optional metric AccessFederationValidate is enabled").Envar("ACCESS_FEDERATION_TARGET").String()
 )
 
 var optionalMetricsList = []string{"artifacts", "replication_status", "federation_status", "open_metrics"}
@@ -36,22 +37,24 @@ type Credentials struct {
 }
 
 type OptionalMetrics struct {
-	Artifacts         bool
-	ReplicationStatus bool
-	FederationStatus  bool
-	OpenMetrics       bool
+	Artifacts                bool
+	ReplicationStatus        bool
+	FederationStatus         bool
+	OpenMetrics              bool
+	AccessFederationValidate bool
 }
 
 // Config represents all configuration options for running the Exporter.
 type Config struct {
-	ListenAddress   string
-	MetricsPath     string
-	ArtiScrapeURI   string
-	Credentials     *Credentials
-	ArtiSSLVerify   bool
-	ArtiTimeout     time.Duration
-	OptionalMetrics OptionalMetrics
-	Logger          *slog.Logger
+	ListenAddress          string
+	MetricsPath            string
+	ArtiScrapeURI          string
+	Credentials            *Credentials
+	ArtiSSLVerify          bool
+	ArtiTimeout            time.Duration
+	OptionalMetrics        OptionalMetrics
+	AccessFederationTarget string
+	Logger                 *slog.Logger
 }
 
 // NewConfig Creates Config for Artifactory exporter
@@ -90,9 +93,20 @@ func NewConfig() (*Config, error) {
 			optMetrics.FederationStatus = true
 		case "open_metrics":
 			optMetrics.OpenMetrics = true
+		case "access_federation_validate":
+			optMetrics.AccessFederationValidate = true
 		default:
 			return nil, fmt.Errorf("unknown optional metric: %s. Valid optional metrics are: %s", metric, optionalMetricsList)
 		}
+	}
+
+	if *accessFederationTarget != "" {
+		_, err = url.Parse(*accessFederationTarget)
+		if err != nil {
+			return nil, err
+		}
+	} else if optMetrics.AccessFederationValidate {
+		return nil, fmt.Errorf("JFrog Access Federation target URL must be set if optional metric AccessFederationValidate is enabled.")
 	}
 
 	logger := l.New(
@@ -102,14 +116,15 @@ func NewConfig() (*Config, error) {
 		},
 	)
 	return &Config{
-		ListenAddress:   *listenAddress,
-		MetricsPath:     *metricsPath,
-		ArtiScrapeURI:   *artiScrapeURI,
-		Credentials:     &credentials,
-		ArtiSSLVerify:   *artiSSLVerify,
-		ArtiTimeout:     *artiTimeout,
-		OptionalMetrics: optMetrics,
-		Logger:          logger,
+		ListenAddress:          *listenAddress,
+		MetricsPath:            *metricsPath,
+		ArtiScrapeURI:          *artiScrapeURI,
+		Credentials:            &credentials,
+		ArtiSSLVerify:          *artiSSLVerify,
+		ArtiTimeout:            *artiTimeout,
+		OptionalMetrics:        optMetrics,
+		AccessFederationTarget: *accessFederationTarget,
+		Logger:                 logger,
 	}, nil
 
 }

--- a/config/config.go
+++ b/config/config.go
@@ -25,7 +25,7 @@ var (
 	accessFederationTarget = kingpin.Flag("access-federation-target", "URL of Jfrog Access Federation Target server. Only required if optional metric AccessFederationValidate is enabled").Envar("ACCESS_FEDERATION_TARGET").String()
 )
 
-var optionalMetricsList = []string{"artifacts", "replication_status", "federation_status", "open_metrics"}
+var optionalMetricsList = []string{"artifacts", "replication_status", "federation_status", "open_metrics", "access_federation_validate"}
 
 // Credentials represents Username and Password or API Key for
 // Artifactory Authentication


### PR DESCRIPTION
[JFrog Access Federation](https://jfrog.com/help/r/jfrog-platform-administration-documentation/access-federation) can be setup for Artifactory to synchronize security related entities - such as users, roles, permissions, or tokens - between connected instances.

In this case [establishing a circle of trust](https://jfrog.com/help/r/jfrog-platform-administration-documentation/why-do-i-need-a-circle-of-trust) between these connected instances is required.

In order to monitor a valid Access Federation the [`/access/api/v1/system/federation/validate_server`](https://jfrog.com/help/r/jfrog-rest-apis/validate-target-for-circle-of-trust) endpoint can be used. Calling this endpoint also requires providing a target server URL in the HTTP POST body.

This pull request adds the functionality to monitor the above Access Federation circle of trust validation endpoint.

The new metric `access_federation_valid` is added to the optional metrics category, since the endpoint requires a few seconds to respond with the validation result. It requires a POST method, which has been added to utils.