### PR TITLE
Fix timeout handling

### DIFF
--- a/artifactory/client.go
+++ b/artifactory/client.go
@@ -44,6 +44,7 @@ func (c *Client) GetAccessFederationTarget() string {
 	return c.accessFederationTarget
 }
 
+// FetchHTTPWithContext makes a GET request to the Artifactory API with a context-aware timeout.
 func (c *Client) FetchHTTPWithContext(ctx context.Context, endpoint string) (*ApiResponse, error) {
 	fullURL := fmt.Sprintf("%s/api/%s", c.URI, endpoint)
 	req, err := http.NewRequestWithContext(ctx, "GET", fullURL, nil)

--- a/artifactory/client.go
+++ b/artifactory/client.go
@@ -64,6 +64,6 @@ func (c *Client) FetchHTTPWithContext(ctx context.Context, endpoint string) (*Ap
 
 	return &ApiResponse{
 		Body:       body,
-		NodeId:     resp.Header.Get("X-Node-Id"),
+		NodeId: resp.Header.Get("X-Artifactory-Node-Id"),
 	}, nil
 }

--- a/artifactory/federation.go
+++ b/artifactory/federation.go
@@ -1,7 +1,11 @@
 package artifactory
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"net/url"
+	"time"
 )
 
 const federationMirrorsLagEndpoint = "federation/status/mirrorsLag"
@@ -27,6 +31,20 @@ type MirrorLag struct {
 type MirrorLags struct {
 	MirrorLags []MirrorLag
 	NodeId     string
+}
+
+type UnavailableMirror struct {
+	RepoKey       string `json:"repoKey"`
+	NodeId        string `json:"nodeId"`
+	Status        string `json:"status"`
+	LocalRepoKey  string `json:"localRepoKey"`
+	RemoteUrl     string `json:"remoteUrl"`
+	RemoteRepoKey string `json:"remoteRepoKey"`
+}
+
+type UnavailableMirrors struct {
+	UnavailableMirrors []UnavailableMirror
+	NodeId             string
 }
 
 // FetchMirrorLags makes the API call to federation/status/mirrorsLag endpoint and returns []MirrorLag

--- a/artifactory/federation.go
+++ b/artifactory/federation.go
@@ -33,17 +33,24 @@ type MirrorLags struct {
 func (c *Client) FetchMirrorLags() (MirrorLags, error) {
 	var mirrorLags MirrorLags
 	c.logger.Debug("Fetching mirror lags")
+
 	resp, err := c.FetchHTTP(federationMirrorsLagEndpoint)
 	if err != nil {
-		if err.(*APIError).status == 404 {
+		var apiErr *APIError
+		var urlErr *url.Error
+		if errors.As(err, &apiErr) && apiErr.status == 404 {
 			return mirrorLags, nil
+		} else if errors.As(err, &urlErr) {
+			c.logger.Error("URL error while fetching mirror lags: ", urlErr)
+			return mirrorLags, err
+		} else {
+			return mirrorLags, err
 		}
-		return mirrorLags, err
 	}
 	mirrorLags.NodeId = resp.NodeId
 
 	if err := json.Unmarshal(resp.Body, &mirrorLags.MirrorLags); err != nil {
-		c.logger.Error("There was an issue when try to unmarshal mirror lags respond")
+		c.logger.Error("There was an issue when trying to unmarshal mirror lags response: ", err)
 		return mirrorLags, &UnmarshalError{
 			message:  err.Error(),
 			endpoint: federationMirrorsLagEndpoint,
@@ -53,34 +60,31 @@ func (c *Client) FetchMirrorLags() (MirrorLags, error) {
 	return mirrorLags, nil
 }
 
-// UnavailableMirror represents single element of API respond from federation/status/unavailableMirrors endpoint
-type UnavailableMirror struct {
-	LocalRepoKey  string `json:"localRepoKey"`
-	RemoteUrl     string `json:"remoteUrl"`
-	RemoteRepoKey string `json:"remoteRepoKey"`
-	Status        string `json:"status"`
-}
-
-type UnavailableMirrors struct {
-	UnavailableMirrors []UnavailableMirror
-	NodeId             string
-}
-
 // FetchUnavailableMirrors makes the API call to federation/status/unavailableMirrors endpoint and returns []UnavailableMirror
 func (c *Client) FetchUnavailableMirrors() (UnavailableMirrors, error) {
 	var unavailableMirrors UnavailableMirrors
 	c.logger.Debug("Fetching unavailable mirrors")
-	resp, err := c.FetchHTTP(federationUnavailableMirrorsEndpoint)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // Set a timeout duration
+	defer cancel()
+
+	resp, err := c.FetchHTTPWithContext(ctx, federationUnavailableMirrorsEndpoint) // Assume FetchHTTPWithContext handles context
 	if err != nil {
-		if err.(*APIError).status == 404 {
+		var apiErr *APIError
+		var urlErr *url.Error
+		if errors.As(err, &apiErr) && apiErr.status == 404 {
 			return unavailableMirrors, nil
+		} else if errors.As(err, &urlErr) {
+			c.logger.Error("URL error while fetching unavailable mirrors: ", urlErr)
+			return unavailableMirrors, err
+		} else {
+			return unavailableMirrors, err
 		}
-		return unavailableMirrors, err
 	}
 	unavailableMirrors.NodeId = resp.NodeId
 
 	if err := json.Unmarshal(resp.Body, &unavailableMirrors.UnavailableMirrors); err != nil {
-		c.logger.Error("There was an issue when try to unmarshal unavailable mirrors respond")
+		c.logger.Error("There was an issue when trying to unmarshal unavailable mirrors response: ", err)
 		return unavailableMirrors, &UnmarshalError{
 			message:  err.Error(),
 			endpoint: federationUnavailableMirrorsEndpoint,

--- a/artifactory/federation.go
+++ b/artifactory/federation.go
@@ -83,10 +83,10 @@ func (c *Client) FetchUnavailableMirrors() (UnavailableMirrors, error) {
 	var unavailableMirrors UnavailableMirrors
 	c.logger.Debug("Fetching unavailable mirrors")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // Set a timeout duration
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	resp, err := c.FetchHTTPWithContext(ctx, federationUnavailableMirrorsEndpoint) // Assume FetchHTTPWithContext handles context
+	resp, err := c.FetchHTTPWithContext(ctx, federationUnavailableMirrorsEndpoint)
 	if err != nil {
 		var apiErr *APIError
 		var urlErr *url.Error


### PR DESCRIPTION
Fix timeout handling in FetchMirrorLags and FetchUnavailableMirrors functions.

This PR updates the FetchMirrorLags and FetchUnavailableMirrors methods to properly handle timeout and network-related errors without panicking.
Previously, the code assumed all errors were *artifactory.APIError and performed an unsafe type assertion, which caused a panic if a different error type (e.g., *url.Error) occurred — such as when a timeout was reached.

This was discovered while scraping /metrics via Prometheus and using a reverse proxy. When Artifactory took too long to respond, the exporter panicked due to improper error handling.

```bash
panic: interface conversion: error is *url.Error, not *artifactory.APIError
time=2025-04-01T18:36:43.579Z level=ERROR msg="There was an error making API call" endpoint=https://artifactory.example.com/artifactory/api/federation/status/mirrorsLag err="Get \"https://artifactory.example.com/artifactory/api/federation/status/mirrorsLag\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)"

goroutine 103997 [running]:
github.com/peimanja/artifactory_exporter/artifactory.(*Client).FetchMirrorLags(0xc00025c1b0)
	/go/artifactory_exporter/artifactory/federation.go:38 +0x33a
github.com/peimanja/artifactory_exporter/collector.(*Exporter).exportFederationMirrorLags(0xc000235ab0, 0x94f1c1?)
	/go/artifactory_exporter/collector/federation.go:11 +0x38
github.com/peimanja/artifactory_exporter/collector.(*Exporter).scrape(0xc000235ab0, 0xc0002e87e0?)
	/go/artifactory_exporter/collector/collector.go:188 +0x2c5
github.com/peimanja/artifactory_exporter/collector.(*Exporter).Collect(0xc000235ab0, 0xc000151f60?)
	/go/artifactory_exporter/collector/collector.go:132 +0x75
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
	/go/pkg/mod/github.com/prometheus/client_golang@v1.11.1/prometheus/registry.go:446 +0x102
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather in goroutine 103993
	/go/pkg/mod/github.com/prometheus/client_golang@v1.11.1/prometheus/registry.go:538 +0xb4b

time=2025-04-01T18:37:01.039Z level=INFO msg="Starting artifactory_exporter" version="(version=v1.15.1, branch=refs/tags/v1.15.1, revision=8fb37cdb73624c7d40f2d980cc2d9603cb1a5948)"
time=2025-04-01T18:37:01.039Z level=INFO msg="Build context" context="(go=go1.21.13, user=github-actions, date=2025-02-27T17:08:02Z)"
time=2025-04-01T18:37:01.039Z level=INFO msg="Listening on address" address=:9531
```

Reproduced using `artifactory_exporter v1.15.1` with `Prometheus v2.53.1` and Artifactory behind a proxy with long response times.

