### PR TITLE
Refactor JSON unmarshalling for mirror and unavailable mirrors responses

### DIFF
--- a/artifactory/federation.go
+++ b/artifactory/federation.go
@@ -22,15 +22,16 @@ func (c *Client) IsFederationEnabled() bool {
 
 // MirrorLag represents single element of API respond from federation/status/mirrorsLag endpoint
 type MirrorLag struct {
-	LocalRepoKey  string `json:"localRepoKey"`
-	RemoteUrl     string `json:"remoteUrl"`
-	RemoteRepoKey string `json:"remoteRepoKey"`
-	LagInMS       int    `json:"lagInMS"`
+	LocalRepoKey               string `json:"localRepoKey"`
+	RemoteUrl                  string `json:"remoteUrl"`
+	RemoteRepoKey              string `json:"remoteRepoKey"`
+	LagInMS                    int    `json:"lagInMS"`
+	EventRegistrationTimeStamp int64  `json:"eventRegistrationTimeStamp"`
 }
 
 type MirrorLags struct {
-	MirrorLags []MirrorLag
-	NodeId     string
+	MirrorLags []MirrorLag `json:"mirrorLags"`
+	NodeId     string      `json:"nodeId"`
 }
 
 type UnavailableMirror struct {
@@ -43,8 +44,8 @@ type UnavailableMirror struct {
 }
 
 type UnavailableMirrors struct {
-	UnavailableMirrors []UnavailableMirror
-	NodeId             string
+	UnavailableMirrors []UnavailableMirror `json:"unavailableMirrors"`
+	NodeId             string              `json:"nodeId"`
 }
 
 // FetchMirrorLags makes the API call to federation/status/mirrorsLag endpoint and returns []MirrorLag
@@ -67,13 +68,13 @@ func (c *Client) FetchMirrorLags() (MirrorLags, error) {
 	}
 	mirrorLags.NodeId = resp.NodeId
 
-	if err := json.Unmarshal(resp.Body, &mirrorLags.MirrorLags); err != nil {
+	var mirrorLagsData []MirrorLag
+	err = json.Unmarshal(resp.Body, &mirrorLagsData)
+	if err != nil {
 		c.logger.Error("There was an issue when trying to unmarshal mirror lags response: ", err)
-		return mirrorLags, &UnmarshalError{
-			message:  err.Error(),
-			endpoint: federationMirrorsLagEndpoint,
-		}
+		return mirrorLags, err
 	}
+	mirrorLags.MirrorLags = mirrorLagsData
 
 	return mirrorLags, nil
 }
@@ -101,12 +102,10 @@ func (c *Client) FetchUnavailableMirrors() (UnavailableMirrors, error) {
 	}
 	unavailableMirrors.NodeId = resp.NodeId
 
-	if err := json.Unmarshal(resp.Body, &unavailableMirrors.UnavailableMirrors); err != nil {
+	err = json.Unmarshal(resp.Body, &unavailableMirrors)
+	if err != nil {
 		c.logger.Error("There was an issue when trying to unmarshal unavailable mirrors response: ", err)
-		return unavailableMirrors, &UnmarshalError{
-			message:  err.Error(),
-			endpoint: federationUnavailableMirrorsEndpoint,
-		}
+		return unavailableMirrors, err
 	}
 
 	return unavailableMirrors, nil


### PR DESCRIPTION
Inadvertently introduced an error:

```bash
time=2025-04-14T21:29:24.377Z level=ERROR msg="There was an issue when trying to unmarshal unavailable mirrors response: " !BADKEY="json: cannot unmarshal object into Go value of type []artifactory.UnavailableMirror"
```

Tested with docker-compose up and I'm no longer seeing that issue:

```bash
exporter-1  | time=2025-04-14T21:44:40.365Z level=DEBUG msg="Fetching unavailable mirrors"
exporter-1  | time=2025-04-14T21:44:40.365Z level=DEBUG msg="Fetching http" path=https://artifactory.example.net/artifactory/api/federation/status/unavailableMirrors
exporter-1  | time=2025-04-14T21:44:40.466Z level=DEBUG msg="No federation unavailable mirrors found"
```

This update fixes the unmarshaling error by:
- Ensuring the UnavailableMirrors and MirrorLags structs match the API response structure.
- Adding JSON tags to struct fields for proper mapping.
- Updating the unmarshaling logic to handle both valid responses and edge cases (e.g., empty arrays).
- These changes ensure that the code can correctly process the API responses without encountering unmarshaling errors.