### PR TITLE
Add support for artifactory_background_tasks metric

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ ARG SOURCE_BRANCH
 ARG BUILD_DATE
 ARG BUILD_USER
 
-
 ARG TARGETPLATFORM
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) go build -a -o /go/bin/artifactory_exporter -ldflags " \

--- a/README.md
+++ b/README.md
@@ -130,25 +130,25 @@ Flags:
       --artifactory.ssl-verify  Flag that enables SSL certificate verification for the scrape URI
       --artifactory.timeout=5s  Timeout for trying to get stats from JFrog Artifactory.
       --optional-metric=metric-name ...
-                                optional metric to be enabled. Pass multiple times to enable multiple optional metrics.
+                                optional metric to be enabled. Valid metrics are: [artifacts replication_status federation_status open_metrics access_federation_validate background_tasks]. Pass multiple times to enable multiple optional metrics.
       --log.level=info          Only log messages with the given severity or above. One of: [debug, info, warn, error]
       --log.format=logfmt       Output format of log messages. One of: [logfmt, json]
       --version                 Show application version.
 ```
 
-| Flag / Environment Variable | Required | Default | Description |
-| --------------------------- | -------- | ------- | ----------- |
-| `web.listen-address`<br/>`WEB_LISTEN_ADDR` | No | `:9531`| Address to listen on for web interface and telemetry. |
-| `web.telemetry-path`<br/>`WEB_TELEMETRY_PATH` | No | `/metrics` | Path under which to expose metrics. |
-| `artifactory.scrape-uri`<br/>`ARTI_SCRAPE_URI` | No | `http://localhost:8081/artifactory` | URI on which to scrape JFrog Artifactory. |
-| `artifactory.ssl-verify`<br/>`ARTI_SSL_VERIFY` | No | `true` | Flag that enables SSL certificate verification for the scrape URI. |
-| `artifactory.timeout`<br/>`ARTI_TIMEOUT` | No | `5s` | Timeout for trying to get stats from JFrog Artifactory. |
-| `optional-metric`| No | | optional metric to be enabled. Pass multiple times to enable multiple optional metrics. |
-| `log.level` | No | `info` | Only log messages with the given severity or above. One of: [debug, info, warn, error]. |
-| `log.format` | No | `logfmt` | Output format of log messages. One of: [logfmt, json]. |
-| `ARTI_USERNAME` | *No | | User to access Artifactory |
-| `ARTI_PASSWORD` | *No | | Password of the user accessing the Artifactory |
-| `ARTI_ACCESS_TOKEN` | *No | | Access token for accessing the Artifactory |
+| Flag / Environment Variable                    | Required | Default                             | Description                                                                             |
+| ---------------------------------------------- | -------- | ----------------------------------- | --------------------------------------------------------------------------------------- |
+| `web.listen-address`<br/>`WEB_LISTEN_ADDR`     | No       | `:9531`                             | Address to listen on for web interface and telemetry.                                   |
+| `web.telemetry-path`<br/>`WEB_TELEMETRY_PATH`  | No       | `/metrics`                          | Path under which to expose metrics.                                                     |
+| `artifactory.scrape-uri`<br/>`ARTI_SCRAPE_URI` | No       | `http://localhost:8081/artifactory` | URI on which to scrape JFrog Artifactory.                                               |
+| `artifactory.ssl-verify`<br/>`ARTI_SSL_VERIFY` | No       | `true`                              | Flag that enables SSL certificate verification for the scrape URI.                      |
+| `artifactory.timeout`<br/>`ARTI_TIMEOUT`       | No       | `5s`                                | Timeout for trying to get stats from JFrog Artifactory.                                 |
+| `optional-metric`                              | No       |                                     | optional metric to be enabled. Pass multiple times to enable multiple optional metrics. |
+| `log.level`                                    | No       | `info`                              | Only log messages with the given severity or above. One of: [debug, info, warn, error]. |
+| `log.format`                                   | No       | `logfmt`                            | Output format of log messages. One of: [logfmt, json].                                  |
+| `ARTI_USERNAME`                                | *No      |                                     | User to access Artifactory                                                              |
+| `ARTI_PASSWORD`                                | *No      |                                     | Password of the user accessing the Artifactory                                          |
+| `ARTI_ACCESS_TOKEN`                            | *No      |                                     | Access token for accessing the Artifactory                                              |
 
 * Either `ARTI_USERNAME` and `ARTI_PASSWORD` or `ARTI_ACCESS_TOKEN` environment variables has to be set.
 
@@ -156,39 +156,39 @@ Flags:
 
 Some metrics are not available with Artifactory OSS license. The exporter returns the following metrics:
 
-| Metric | Description | Labels | OSS support |
-| ------ | ----------- | ------ | ------ |
-| artifactory_up | Was the last scrape of Artifactory successful. |  | &#9989; |
-| artifactory_exporter_build_info | Exporter build information. | `version`, `revision`, `branch`, `goversion` | &#9989; |
-| artifactory_exporter_total_scrapes | Current total artifactory scrapes. |  | &#9989; |
-| artifactory_exporter_total_api_errors | Current total Artifactory API errors when scraping for stats. |  | &#9989; |
-| artifactory_exporter_json_parse_failures |Number of errors while parsing Json. |  | &#9989; |
-| artifactory_replication_enabled | Replication status for an Artifactory repository (1 = enabled). | `name`, `type`, `cron_exp`, `status` | |
-| artifactory_security_certificates | SSL certificate name and expiry as labels, seconds to expiration as value | `alias`, `expires`, `issued_by` | |
-| artifactory_security_groups | Number of Artifactory groups. | | |
-| artifactory_security_users | Number of Artifactory users for each realm. | `realm` | |
-| artifactory_storage_artifacts | Total artifacts count stored in Artifactory. |  | &#9989; |
-| artifactory_storage_artifacts_size_bytes | Total artifacts Size stored in Artifactory in bytes. |  | &#9989; |
-| artifactory_storage_binaries | Total binaries count stored in Artifactory. |  | &#9989; |
-| artifactory_storage_binaries_size_bytes | Total binaries Size stored in Artifactory in bytes. |  | &#9989; |
-| artifactory_storage_filestore_bytes | Total space in the file store in bytes. | `storage_dir`, `storage_type` | &#9989; |
-| artifactory_storage_filestore_used_bytes | Space used in the file store in bytes. | `storage_dir`, `storage_type` | &#9989; |
-| artifactory_storage_filestore_free_bytes | Space free in the file store in bytes. | `storage_dir`, `storage_type` | &#9989; |
-| artifactory_storage_repo_used_bytes | Space used by an Artifactory repository in bytes. | `name`, `package_type`, `type` | &#9989; |
-| artifactory_storage_repo_folders | Number of folders in an Artifactory repository. | `name`, `package_type`, `type` | &#9989; |
-| artifactory_storage_repo_files | Number files in an Artifactory repository. | `name`, `package_type`, `type` | &#9989; |
-| artifactory_storage_repo_items | Number Items in an Artifactory repository. | `name`, `package_type`, `type` | &#9989; |
-| artifactory_artifacts_created_1m | Number of artifacts created in the repo (last 1 minute). | `name`, `package_type`, `type` | &#9989; |
-| artifactory_artifacts_created_5m | Number of artifacts created in the repo (last 5 minutes). | `name`, `package_type`, `type` | &#9989; |
-| artifactory_artifacts_created_15m | Number of artifacts created in the repo (last 15 minutes). | `name`, `package_type`, `type` | &#9989; |
-| artifactory_artifacts_downloaded_1m | Number of artifacts downloaded from the repository (last 1 minute). | `name`, `package_type`, `type` | &#9989; |
-| artifactory_artifacts_downloaded_5m | Number of artifacts downloaded from the repository (last 5 minutes). | `name`, `package_type`, `type` | &#9989; |
-| artifactory_artifacts_downloaded_15m | Number of artifacts downloaded from the repository (last 15 minute). | `name`, `package_type`, `type` | &#9989; |
-| artifactory_system_healthy | Is Artifactory working properly (1 = healthy). | | &#9989; |
-| artifactory_system_license | License type and expiry as labels, seconds to expiration as value | `type`, `licensed_to`, `expires` | &#9989; |
-| artifactory_system_version | Version and revision of Artifactory as labels. | `version`, `revision` | &#9989; |
-| artifactory_federation_mirror_lag | Federation mirror lag in milliseconds. | `name`, `remote_url`, `remote_name` | |
-| artifactory_federation_unavailable_mirror | Unsynchronized federated mirror status. | `status`, `name`, `remote_url`, `remote_name` | |
+| Metric                                    | Description                                                               | Labels                                        | OSS support |
+| ----------------------------------------- | ------------------------------------------------------------------------- | --------------------------------------------- | ----------- |
+| artifactory_up                            | Was the last scrape of Artifactory successful.                            |                                               | &#9989;     |
+| artifactory_exporter_build_info           | Exporter build information.                                               | `version`, `revision`, `branch`, `goversion`  | &#9989;     |
+| artifactory_exporter_total_scrapes        | Current total artifactory scrapes.                                        |                                               | &#9989;     |
+| artifactory_exporter_total_api_errors     | Current total Artifactory API errors when scraping for stats.             |                                               | &#9989;     |
+| artifactory_exporter_json_parse_failures  | Number of errors while parsing Json.                                      |                                               | &#9989;     |
+| artifactory_replication_enabled           | Replication status for an Artifactory repository (1 = enabled).           | `name`, `type`, `cron_exp`, `status`          |             |
+| artifactory_security_certificates         | SSL certificate name and expiry as labels, seconds to expiration as value | `alias`, `expires`, `issued_by`               |             |
+| artifactory_security_groups               | Number of Artifactory groups.                                             |                                               |             |
+| artifactory_security_users                | Number of Artifactory users for each realm.                               | `realm`                                       |             |
+| artifactory_storage_artifacts             | Total artifacts count stored in Artifactory.                              |                                               | &#9989;     |
+| artifactory_storage_artifacts_size_bytes  | Total artifacts Size stored in Artifactory in bytes.                      |                                               | &#9989;     |
+| artifactory_storage_binaries              | Total binaries count stored in Artifactory.                               |                                               | &#9989;     |
+| artifactory_storage_binaries_size_bytes   | Total binaries Size stored in Artifactory in bytes.                       |                                               | &#9989;     |
+| artifactory_storage_filestore_bytes       | Total space in the file store in bytes.                                   | `storage_dir`, `storage_type`                 | &#9989;     |
+| artifactory_storage_filestore_used_bytes  | Space used in the file store in bytes.                                    | `storage_dir`, `storage_type`                 | &#9989;     |
+| artifactory_storage_filestore_free_bytes  | Space free in the file store in bytes.                                    | `storage_dir`, `storage_type`                 | &#9989;     |
+| artifactory_storage_repo_used_bytes       | Space used by an Artifactory repository in bytes.                         | `name`, `package_type`, `type`                | &#9989;     |
+| artifactory_storage_repo_folders          | Number of folders in an Artifactory repository.                           | `name`, `package_type`, `type`                | &#9989;     |
+| artifactory_storage_repo_files            | Number files in an Artifactory repository.                                | `name`, `package_type`, `type`                | &#9989;     |
+| artifactory_storage_repo_items            | Number Items in an Artifactory repository.                                | `name`, `package_type`, `type`                | &#9989;     |
+| artifactory_artifacts_created_1m          | Number of artifacts created in the repo (last 1 minute).                  | `name`, `package_type`, `type`                | &#9989;     |
+| artifactory_artifacts_created_5m          | Number of artifacts created in the repo (last 5 minutes).                 | `name`, `package_type`, `type`                | &#9989;     |
+| artifactory_artifacts_created_15m         | Number of artifacts created in the repo (last 15 minutes).                | `name`, `package_type`, `type`                | &#9989;     |
+| artifactory_artifacts_downloaded_1m       | Number of artifacts downloaded from the repository (last 1 minute).       | `name`, `package_type`, `type`                | &#9989;     |
+| artifactory_artifacts_downloaded_5m       | Number of artifacts downloaded from the repository (last 5 minutes).      | `name`, `package_type`, `type`                | &#9989;     |
+| artifactory_artifacts_downloaded_15m      | Number of artifacts downloaded from the repository (last 15 minute).      | `name`, `package_type`, `type`                | &#9989;     |
+| artifactory_system_healthy                | Is Artifactory working properly (1 = healthy).                            |                                               | &#9989;     |
+| artifactory_system_license                | License type and expiry as labels, seconds to expiration as value         | `type`, `licensed_to`, `expires`              | &#9989;     |
+| artifactory_system_version                | Version and revision of Artifactory as labels.                            | `version`, `revision`                         | &#9989;     |
+| artifactory_federation_mirror_lag         | Federation mirror lag in milliseconds.                                    | `name`, `remote_url`, `remote_name`           |             |
+| artifactory_federation_unavailable_mirror | Unsynchronized federated mirror status.                                   | `status`, `name`, `remote_url`, `remote_name` |             |
 
 * Common labels:
   * `node_id`: Artifactory node ID that the metric is scraped from.

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Supported optional metrics:
 * `federation_status` - Extracts federation metrics. Enabling this will add two new metrics: `artifactory_federation_mirror_lag`, and `artifactory_federation_unavailable_mirror`. Please note that these metrics are only available in Artifactory Enterprise Plus and version 7.18.3 and above.
 * `open_metrics` - Exposes Open Metrics from the JFrog Platform. For more information about Open Metrics, please refer to [JFrog Platform Open Metrics](https://jfrog.com/help/r/jfrog-platform-administration-documentation/open-metrics).
 * `access_federation_validate` - Validates whether trust is established towards a given JFrog Access Federation target server. Requires optional parameter `access-federation-target` to be set to the URL of the target server as well as token-based authentication. For more information, please refer to [JFrog Access Federation Circle of Trust validation](https://jfrog.com/help/r/jfrog-rest-apis/validate-target-for-circle-of-trust).
+* `background_tasks` - Tracks the number of Artifactory background tasks by type and state. Enabling this will add the `artifactory_background_tasks` metric. Use this to monitor scheduled, running, stopped, or canceled tasks.
 
 ### Grafana Dashboard
 

--- a/artifactory/client.go
+++ b/artifactory/client.go
@@ -65,7 +65,7 @@ func (c *Client) FetchHTTPWithContext(ctx context.Context, endpoint string) (*Ap
 	}
 
 	return &ApiResponse{
-		Body:       body,
+		Body:   body,
 		NodeId: resp.Header.Get("X-Artifactory-Node-Id"),
 	}, nil
 }
@@ -95,7 +95,6 @@ func (c *Client) FetchBackgroundTasks() ([]BackgroundTask, error) {
 	return tasksResponse.Tasks, nil
 }
 
-// BackgroundTask represents a single background task in Artifactory
 type BackgroundTask struct {
 	ID          string `json:"id"`
 	Type        string `json:"type"`

--- a/artifactory/replication.go
+++ b/artifactory/replication.go
@@ -56,7 +56,7 @@ func (c *Client) FetchReplications() (Replications, error) {
 		}
 	}
 
-	if c.optionalMetrics.ReplicationStatus {
+	if c.OptionalMetrics.ReplicationStatus {
 		c.logger.Debug("Fetching replications status")
 		for i, replication := range replications.Replications {
 			var status ReplicationStatus

--- a/artifactory_exporter.go
+++ b/artifactory_exporter.go
@@ -45,7 +45,14 @@ func main() {
 		"Listening on address",
 		"address", conf.ListenAddress,
 	)
-	http.Handle(conf.MetricsPath, promhttp.Handler())
+	http.HandleFunc(conf.MetricsPath, func(w http.ResponseWriter, r *http.Request) {
+		conf.Logger.Debug(
+			"Prometheus scrape",
+			"remote", r.RemoteAddr,
+			"user_agent", r.UserAgent(),
+		)
+		promhttp.Handler().ServeHTTP(w, r)
+	})
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`<html>
              <head><title>JFrog Artifactory Exporter</title></head>

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -150,10 +150,13 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 func (e *Exporter) scrape(ch chan<- prometheus.Metric) (up float64) {
 	e.totalScrapes.Inc()
 
+	// Reset the metric to avoid duplicate data
+	backgroundTaskMetrics.Reset()
+
 	// Collect and export open metrics
 	if e.optionalMetrics.OpenMetrics {
 		err := e.exportOpenMetrics(ch)
-		if err != nil {
+		if (err != nil) {
 			return 0
 		}
 	}
@@ -211,9 +214,6 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) (up float64) {
 			e.logger.Error("Error fetching background tasks", "error", err)
 			return 0
 		}
-
-		// Reset the metric to avoid stale data
-		backgroundTaskMetrics.Reset()
 
 		for _, task := range tasks {
 			backgroundTaskMetrics.WithLabelValues(task.Type, task.State).Set(1)


### PR DESCRIPTION
## Description

This PR introduces support for the `artifactory_background_tasks` metric, which provides observability into the background tasks running in Artifactory. The metric aggregates tasks by their type and state to ensure low cardinality while delivering valuable insights.

## Resolves

This PR resolves [Issue #129](https://github.com/peimanja/artifactory_exporter/issues/129)

## Changes Made

1. Introduced the background_tasks optional metric.
2. Integrated the metric into the scrape cycle, ensuring synchronous collection with other metrics.
3. Prevented duplicate metrics by resetting the gauge at the start of each scrape and simplified label values by stripping verbose Java class names for better clarity.

## Example Metric Output

Here is an example of the artifactory_background_tasks metric output:

before strip:
```shell
# HELP artifactory_background_tasks Number of Artifactory background tasks by type and state.
# TYPE artifactory_background_tasks gauge
artifactory_background_tasks{state="running",type="org.artifactory.sh.cleanup.job.BinaryStoreGarbageCollectorJob"} 1
artifactory_background_tasks{state="scheduled",type="org.artifactory.addon.bh.scheduler.BundleCleanupJob"} 1
artifactory_background_tasks{state="scheduled",type="org.artifactory.addon.bh.scheduler.BundlePromotionXrayJob"} 1
artifactory_background_tasks{state="scheduled",type="org.artifactory.addon.bh.scheduler.BundleXrayJob"} 1
```

after strip:
```shell
# HELP artifactory_background_tasks Number of Artifactory background tasks by type and state.
# TYPE artifactory_background_tasks gauge
artifactory_background_tasks{state="running",type="BinaryStoreGarbageCollectorJob"} 1
artifactory_background_tasks{state="scheduled",type="BundleCleanupJob"} 1
artifactory_background_tasks{state="scheduled",type="BundlePromotionXrayJob"} 1
artifactory_background_tasks{state="scheduled",type="BundleXrayJob"} 1
```

## Testing

Verified that the artifactory_background_tasks metric is included in the /metrics endpoint when the optional metric is enabled.
Tested with various Artifactory background tasks, including running and scheduled states.
Ensured no duplicate metrics are registered during a single scrape cycle.

## Notes

This feature is optional and must be enabled using the `--optional-metric=background_tasks` flag.
The metric is designed to aggregate tasks by type and state to maintain low cardinality.