### PR TITLE
Add option to select artifacts time interval

### DIFF
--- a/artifactory/client.go
+++ b/artifactory/client.go
@@ -47,7 +47,7 @@ func NewClient(conf *config.Config) *Client {
 		URI:                    conf.ArtiScrapeURI,
 		authMethod:             conf.Credentials.AuthMethod,
 		cred:                   *conf.Credentials,
-		OptionalMetrics:        conf.OptionalMetrics,
+		OptionalMetrics:        conf.ExporterRuntimeConfig.OptionalMetrics,
 		accessFederationTarget: conf.AccessFederationTarget,
 		client:                 client,
 		logger:                 logger,

--- a/artifactory/client_test.go
+++ b/artifactory/client_test.go
@@ -15,13 +15,13 @@ import (
 // Mock configuration for testing
 func createTestConfig() *config.Config {
 	return &config.Config{
-		ArtiScrapeURI:   "http://localhost:8081/artifactory",
-		ArtiSSLVerify:   false,
-		ArtiTimeout:     5 * time.Second,
-		UseCache:        false,
-		CacheTTL:        5 * time.Minute,
-		CacheTimeout:    30 * time.Second,
-		OptionalMetrics: config.OptionalMetrics{},
+		ArtiScrapeURI:         "http://localhost:8081/artifactory",
+		ArtiSSLVerify:         false,
+		ArtiTimeout:           5 * time.Second,
+		UseCache:              false,
+		CacheTTL:              5 * time.Minute,
+		CacheTimeout:          30 * time.Second,
+		ExporterRuntimeConfig: &config.ExporterRuntimeConfig{},
 		Credentials: &config.Credentials{
 			AuthMethod: "userPass",
 			Username:   "test",
@@ -322,7 +322,7 @@ func TestClientConfiguration(t *testing.T) {
 
 func TestOptionalMetricsConfiguration(t *testing.T) {
 	conf := createTestConfig()
-	conf.OptionalMetrics = config.OptionalMetrics{
+	conf.ExporterRuntimeConfig.OptionalMetrics = config.OptionalMetrics{
 		Artifacts:                true,
 		ReplicationStatus:        true,
 		FederationStatus:         false,

--- a/artifactory_exporter.go
+++ b/artifactory_exporter.go
@@ -32,6 +32,7 @@ func main() {
 		)
 		os.Exit(1)
 	}
+	collector.InitMetrics(exporter)
 	prometheus.MustRegister(exporter)
 	conf.Logger.Info(
 		"Starting artifactory_exporter",

--- a/collector/artifacts.go
+++ b/collector/artifacts.go
@@ -35,7 +35,7 @@ func (e *Exporter) findArtifacts(period string, queryType string) (artifactQuery
 			"Query Type is not supported",
 			"query", queryType,
 		)
-		return artifacts, fmt.Errorf("Query Type is not supported: %s", queryType)
+		return artifacts, fmt.Errorf("query Type is not supported: %s", queryType)
 	}
 	resp, err := e.client.QueryAQL([]byte(query))
 	if err != nil {

--- a/collector/artifacts.go
+++ b/collector/artifacts.go
@@ -62,16 +62,16 @@ func (e *Exporter) getTotalArtifacts(r []repoSummary) ([]repoSummary, error) {
 	timeIntervals := e.exporterRuntimeConfig.ArtifactsTimeIntervals
 
 	groupedRepoSummary := make(map[string]*repoSummary, len(repoSummaries))
-	for rep_i, repo := range repoSummaries {
-		repoSummaries[rep_i].RepoArtifactsSummary = make([]RepoArtifactsSummary, len(timeIntervals))
+	for i := range repoSummaries {
+		repoSummaries[i].RepoArtifactsSummary = make([]RepoArtifactsSummary, len(timeIntervals))
 		// Fill the slice directly
-		for interval_i, timeInterval := range timeIntervals {
-			repoSummaries[rep_i].RepoArtifactsSummary[interval_i] = RepoArtifactsSummary{period: timeInterval.ShortPeriod}
+		for j, timeInterval := range timeIntervals {
+			repoSummaries[i].RepoArtifactsSummary[j] = RepoArtifactsSummary{period: timeInterval.ShortPeriod}
 		}
-		groupedRepoSummary[repo.Name] = &repoSummaries[rep_i]
+		groupedRepoSummary[repoSummaries[i].Name] = &repoSummaries[i]
 	}
 
-	for interval_i, timeInterval := range timeIntervals {
+	for intervalIdx, timeInterval := range timeIntervals {
 		created, err := e.findArtifacts(timeInterval.Period, "created")
 		if err != nil {
 			return nil, err
@@ -82,10 +82,14 @@ func (e *Exporter) getTotalArtifacts(r []repoSummary) ([]repoSummary, error) {
 		}
 
 		for _, item := range created.Results {
-			groupedRepoSummary[item.Repo].RepoArtifactsSummary[interval_i].TotalCreated++
+			if repo, exists := groupedRepoSummary[item.Repo]; exists {
+				repo.RepoArtifactsSummary[intervalIdx].TotalCreated++
+			}
 		}
 		for _, item := range downloaded.Results {
-			groupedRepoSummary[item.Repo].RepoArtifactsSummary[interval_i].TotalDownloaded++
+			if repo, exists := groupedRepoSummary[item.Repo]; exists {
+				repo.RepoArtifactsSummary[intervalIdx].TotalDownloaded++
+			}
 		}
 	}
 

--- a/collector/artifacts.go
+++ b/collector/artifacts.go
@@ -57,138 +57,68 @@ func (e *Exporter) findArtifacts(period string, queryType string) (artifactQuery
 }
 
 func (e *Exporter) getTotalArtifacts(r []repoSummary) ([]repoSummary, error) {
-	created1m, err := e.findArtifacts("1minutes", "created")
-	if err != nil {
-		return nil, err
-	}
-	created5m, err := e.findArtifacts("5minutes", "created")
-	if err != nil {
-		return nil, err
-	}
-	created15m, err := e.findArtifacts("15minutes", "created")
-	if err != nil {
-		return nil, err
-	}
-	downloaded1m, err := e.findArtifacts("1minutes", "downloaded")
-	if err != nil {
-		return nil, err
-	}
-	downloaded5m, err := e.findArtifacts("5minutes", "downloaded")
-	if err != nil {
-		return nil, err
-	}
-	downloaded15m, err := e.findArtifacts("15minutes", "downloaded")
-	if err != nil {
-		return nil, err
+	repoSummaries := r
+
+	timeIntervals := e.exporterRuntimeConfig.ArtifactsTimeIntervals
+
+	groupedRepoSummary := make(map[string]*repoSummary, len(repoSummaries))
+	for rep_i, repo := range repoSummaries {
+		repoSummaries[rep_i].RepoArtifactsSummary = make([]RepoArtifactsSummary, len(timeIntervals))
+		// Fill the slice directly
+		for interval_i, timeInterval := range timeIntervals {
+			repoSummaries[rep_i].RepoArtifactsSummary[interval_i] = RepoArtifactsSummary{period: timeInterval.ShortPeriod}
+		}
+		groupedRepoSummary[repo.Name] = &repoSummaries[rep_i]
 	}
 
-	repoSummaries := r
-	for i := range repoSummaries {
-		for _, k := range created1m.Results {
-			repoSummaries[i].NodeId = created1m.NodeId
-			if repoSummaries[i].Name == k.Repo {
-				repoSummaries[i].TotalCreate1m++
-			}
+	for interval_i, timeInterval := range timeIntervals {
+		created, err := e.findArtifacts(timeInterval.Period, "created")
+		if err != nil {
+			return nil, err
 		}
-		for _, k := range created5m.Results {
-			repoSummaries[i].NodeId = created1m.NodeId
-			if repoSummaries[i].Name == k.Repo {
-				repoSummaries[i].TotalCreated5m++
-			}
+		downloaded, err := e.findArtifacts(timeInterval.Period, "downloaded")
+		if err != nil {
+			return nil, err
 		}
-		for _, k := range created15m.Results {
-			repoSummaries[i].NodeId = created1m.NodeId
-			if repoSummaries[i].Name == k.Repo {
-				repoSummaries[i].TotalCreated15m++
-			}
+
+		for _, item := range created.Results {
+			groupedRepoSummary[item.Repo].RepoArtifactsSummary[interval_i].TotalCreated++
 		}
-		for _, k := range downloaded1m.Results {
-			repoSummaries[i].NodeId = created1m.NodeId
-			if repoSummaries[i].Name == k.Repo {
-				repoSummaries[i].TotalDownloaded1m++
-			}
-		}
-		for _, k := range downloaded5m.Results {
-			repoSummaries[i].NodeId = created1m.NodeId
-			if repoSummaries[i].Name == k.Repo {
-				repoSummaries[i].TotalDownloaded5m++
-			}
-		}
-		for _, k := range downloaded15m.Results {
-			repoSummaries[i].NodeId = created1m.NodeId
-			if repoSummaries[i].Name == k.Repo {
-				repoSummaries[i].TotalDownloaded15m++
-			}
+		for _, item := range downloaded.Results {
+			groupedRepoSummary[item.Repo].RepoArtifactsSummary[interval_i].TotalDownloaded++
 		}
 	}
+
 	return repoSummaries, nil
 }
 
 func (e *Exporter) exportArtifacts(repoSummaries []repoSummary, ch chan<- prometheus.Metric) {
 	for _, repoSummary := range repoSummaries {
-		for metricName, metric := range artifactsMetrics {
-			switch metricName {
-			case "created1m":
-				e.logger.Debug(
-					logDbgMsgRegMetric,
-					"metric", metricName,
-					"repo", repoSummary.Name,
-					"type", repoSummary.Type,
-					"package_type", repoSummary.PackageType,
-					"value", repoSummary.TotalCreate1m,
-				)
-				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, repoSummary.TotalCreate1m, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
-			case "created5m":
-				e.logger.Debug(
-					logDbgMsgRegMetric,
-					"metric", metricName,
-					"repo", repoSummary.Name,
-					"type", repoSummary.Type,
-					"package_type", repoSummary.PackageType,
-					"value", repoSummary.TotalCreated5m,
-				)
-				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, repoSummary.TotalCreated5m, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
-			case "created15m":
-				e.logger.Debug(
-					logDbgMsgRegMetric,
-					"metric", metricName,
-					"repo", repoSummary.Name,
-					"type", repoSummary.Type,
-					"package_type", repoSummary.PackageType,
-					"value", repoSummary.TotalCreated15m,
-				)
-				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, repoSummary.TotalCreated15m, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
-			case "downloaded1m":
-				e.logger.Debug(
-					logDbgMsgRegMetric,
-					"metric", metricName,
-					"repo", repoSummary.Name,
-					"type", repoSummary.Type,
-					"package_type", repoSummary.PackageType,
-					"value", repoSummary.TotalDownloaded1m,
-				)
-				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, repoSummary.TotalDownloaded1m, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
-			case "downloaded5m":
-				e.logger.Debug(
-					logDbgMsgRegMetric,
-					"metric", metricName,
-					"repo", repoSummary.Name,
-					"type", repoSummary.Type,
-					"package_type", repoSummary.PackageType,
-					"value", repoSummary.TotalDownloaded5m,
-				)
-				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, repoSummary.TotalDownloaded5m, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
-			case "downloaded15m":
-				e.logger.Debug(
-					logDbgMsgRegMetric,
-					"metric", metricName,
-					"repo", repoSummary.Name,
-					"type", repoSummary.Type,
-					"package_type", repoSummary.PackageType,
-					"value", repoSummary.TotalDownloaded15m,
-				)
-				ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, repoSummary.TotalDownloaded15m, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
-			}
+		for _, repoArtifactsSummary := range repoSummary.RepoArtifactsSummary {
+			createdMetricName := fmt.Sprintf("created_%s", repoArtifactsSummary.period)
+			downloadedMetricName := fmt.Sprintf("downloaded_%s", repoArtifactsSummary.period)
+
+			e.logger.Debug(
+				logDbgMsgRegMetric,
+				"metric", createdMetricName,
+				"repo", repoSummary.Name,
+				"type", repoSummary.Type,
+				"package_type", repoSummary.PackageType,
+				"value", repoArtifactsSummary.TotalCreated,
+			)
+			createdMetric := artifactsMetrics[createdMetricName]
+			ch <- prometheus.MustNewConstMetric(createdMetric, prometheus.GaugeValue, repoArtifactsSummary.TotalCreated, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
+
+			e.logger.Debug(
+				logDbgMsgRegMetric,
+				"metric", downloadedMetricName,
+				"repo", repoSummary.Name,
+				"type", repoSummary.Type,
+				"package_type", repoSummary.PackageType,
+				"value", repoArtifactsSummary.TotalCreated,
+			)
+			downloadedMetric := artifactsMetrics[downloadedMetricName]
+			ch <- prometheus.MustNewConstMetric(downloadedMetric, prometheus.GaugeValue, repoArtifactsSummary.TotalCreated, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
 		}
 	}
 }

--- a/collector/artifacts.go
+++ b/collector/artifacts.go
@@ -115,10 +115,10 @@ func (e *Exporter) exportArtifacts(repoSummaries []repoSummary, ch chan<- promet
 				"repo", repoSummary.Name,
 				"type", repoSummary.Type,
 				"package_type", repoSummary.PackageType,
-				"value", repoArtifactsSummary.TotalCreated,
+				"value", repoArtifactsSummary.TotalDownloaded,
 			)
 			downloadedMetric := artifactsMetrics[downloadedMetricName]
-			ch <- prometheus.MustNewConstMetric(downloadedMetric, prometheus.GaugeValue, repoArtifactsSummary.TotalCreated, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
+			ch <- prometheus.MustNewConstMetric(downloadedMetric, prometheus.GaugeValue, repoArtifactsSummary.TotalDownloaded, repoSummary.Name, repoSummary.Type, repoSummary.PackageType, repoSummary.NodeId)
 		}
 	}
 }

--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -13,14 +13,14 @@ import (
 // Exporter collects JFrog Artifactory stats from the given URI and
 // exports them using the prometheus metrics package.
 type Exporter struct {
-	client          *artifactory.Client
-	optionalMetrics config.OptionalMetrics
-	mutex           sync.RWMutex
+	client                *artifactory.Client
+	exporterRuntimeConfig config.ExporterRuntimeConfig
+	mutex                 sync.RWMutex
 
 	up                                              prometheus.Gauge
 	totalScrapes, totalAPIErrors, jsonParseFailures prometheus.Counter
 	logger                                          *slog.Logger
-	backgroundTaskMetrics *prometheus.GaugeVec
+	backgroundTaskMetrics                           *prometheus.GaugeVec
 }
 
 // NewExporter returns an initialized Exporter.
@@ -37,8 +37,8 @@ func NewExporter(conf *config.Config) (*Exporter, error) {
 	)
 
 	return &Exporter{
-		client:          client,
-		optionalMetrics: conf.OptionalMetrics,
+		client:                client,
+		exporterRuntimeConfig: *conf.ExporterRuntimeConfig,
 		up: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "up",
@@ -59,7 +59,7 @@ func NewExporter(conf *config.Config) (*Exporter, error) {
 			Name:      "exporter_json_parse_failures",
 			Help:      "Number of errors while parsing Json.",
 		}),
-		logger:                  conf.Logger,
+		logger:                conf.Logger,
 		backgroundTaskMetrics: backgroundTaskMetrics,
 	}, nil
 }

--- a/collector/storage.go
+++ b/collector/storage.go
@@ -84,22 +84,23 @@ func (e *Exporter) exportFilestore(metricName string, metric *prometheus.Desc, s
 	ch <- prometheus.MustNewConstMetric(metric, prometheus.GaugeValue, value, fileStoreType, fileStoreDir, nodeId)
 }
 
+type RepoArtifactsSummary struct {
+	period          string // 30s 1m 15m 2h
+	TotalCreated    float64
+	TotalDownloaded float64
+}
+
 type repoSummary struct {
-	Name               string
-	Type               string
-	FoldersCount       float64
-	FilesCount         float64
-	UsedSpace          float64
-	ItemsCount         float64
-	PackageType        string
-	Percentage         float64
-	TotalCreate1m      float64
-	TotalCreated5m     float64
-	TotalCreated15m    float64
-	TotalDownloaded1m  float64
-	TotalDownloaded5m  float64
-	TotalDownloaded15m float64
-	NodeId             string
+	Name                 string
+	Type                 string
+	FoldersCount         float64
+	FilesCount           float64
+	UsedSpace            float64
+	ItemsCount           float64
+	PackageType          string
+	Percentage           float64
+	RepoArtifactsSummary []RepoArtifactsSummary
+	NodeId               string
 }
 
 func (e *Exporter) extractRepo(storageInfo artifactory.StorageInfo) ([]repoSummary, error) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -330,6 +330,38 @@ func TestTimeoutValidation(t *testing.T) {
 	}
 }
 
+func TestGetAqlTimeFormat(t *testing.T) {
+	type Expected struct {
+		duration int
+		unit     string
+	}
+	tests := []struct {
+		name     string
+		duration time.Duration
+		expected Expected
+	}{
+		{"Valid seconds", 5 * time.Second, Expected{5, "second"}},
+		{"Valid large seconds", 555 * time.Second, Expected{555, "second"}},
+		{"Valid minutes", 5 * time.Minute, Expected{5, "minutes"}},
+		{"Valid large minutes", 555 * time.Minute, Expected{555, "minutes"}},
+		{"Valid days", 5 * 24 * time.Hour, Expected{5, "days"}},
+		{"Valid weeks", 5 * 7 * 24 * time.Hour, Expected{5, "weeks"}},
+		{"Transform minutes to seconds", time.Duration(1.5 * float64(time.Minute)), Expected{90, "second"}},
+		{"Transform hour to minutes", 4 * time.Hour, Expected{240, "minutes"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			duration, unit := getAqlTimeFormat(tt.duration)
+
+			fmt.Println(duration, tt.expected.duration, unit, tt.expected.unit)
+			if duration != tt.expected.duration || unit != tt.expected.unit {
+				t.Errorf("Parsed duration = %v, want %v; unit = %v, want %v", duration, tt.expected.duration, unit, tt.expected.unit)
+			}
+		})
+	}
+}
+
 func TestOptionalMetricsList(t *testing.T) {
 	expectedMetrics := []string{
 		"artifacts",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -354,7 +354,6 @@ func TestGetAqlTimeFormat(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			duration, unit := getAqlTimeFormat(tt.duration)
 
-			fmt.Println(duration, tt.expected.duration, unit, tt.expected.unit)
 			if duration != tt.expected.duration || unit != tt.expected.unit {
 				t.Errorf("Parsed duration = %v, want %v; unit = %v, want %v", duration, tt.expected.duration, unit, tt.expected.unit)
 			}


### PR DESCRIPTION
# Problem
In my opinion `artifacts-time-interval` should be equal prometheus `scrape_interval` interval.
artifactory_exporter do 6 AQL request for artifacts metrics: 2 per time interval (1m, 5m, 15m).
We don't use metrics *_5m and *_15m, but they do affect performance during high load.

# Solution
Add option to select artifacts time interval
```help
--artifacts-time-interval=1m... ...
                                Time interval for created and downloaded stats
```
```
./artifactory_exporter --artifacts-scrape-interval 5m --artifacts-scrape-interval 30m
```