### PR TITLE
Add xray openMetrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Flags:
       --artifactory.scrape-uri="http://localhost:8081/artifactory"
                                 URI on which to scrape JFrog Artifactory.
       --xray.scrape-uri="http://localhost:8081/xray"
-                                URI on which to scrape JFrog Artifactory.
+                                URI on which to scrape JFrog Xray.
       --artifactory.ssl-verify  Flag that enables SSL certificate verification for the scrape URI
       --artifactory.timeout=5s  Timeout for trying to get stats from JFrog Artifactory.
       --access-federation-target=ACCESS-FEDERATION-TARGET
@@ -158,7 +158,7 @@ Flags:
 | `web.listen-address`<br/>`WEB_LISTEN_ADDR`     | No       | `:9531`                             | Address to listen on for web interface and telemetry.                                                                                                                                    |
 | `web.telemetry-path`<br/>`WEB_TELEMETRY_PATH`  | No       | `/metrics`                          | Path under which to expose metrics.                                                                                                                                                      |
 | `artifactory.scrape-uri`<br/>`ARTI_SCRAPE_URI` | No       | `http://localhost:8081/artifactory` | URI on which to scrape JFrog Artifactory.                                                                                                                                                |
-| `xray.scrape-uri`<br/>`XRAY_SCRAPE_URI` | No | `http://localhost:8081/xray` | URI on which to scrape JFrog Artifactory.                                                                                                                                                                    |
+| `xray.scrape-uri`<br/>`XRAY_SCRAPE_URI` | No | `http://localhost:8081/xray` | URI on which to scrape JFrog Xray.                                                                                                                                                                    |
 | `artifactory.ssl-verify`<br/>`ARTI_SSL_VERIFY` | No       | `true`                              | Flag that enables SSL certificate verification for the scrape URI.                                                                                                                       |
 | `artifactory.timeout`<br/>`ARTI_TIMEOUT`       | No       | `5s`                                | Timeout for trying to get stats from JFrog Artifactory.                                                                                                                                  |
 | `use-cache`<br/>`USE_CACHE`                    | No       | `false`                             | Use caching for API responses to circumvent timeouts.                                                                                                                                    |

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Flags:
                                 Path under which to expose metrics.
       --artifactory.scrape-uri="http://localhost:8081/artifactory"
                                 URI on which to scrape JFrog Artifactory.
+      --xray.scrape-uri="http://localhost:8081/xray"
+                                URI on which to scrape JFrog Artifactory.
       --artifactory.ssl-verify  Flag that enables SSL certificate verification for the scrape URI
       --artifactory.timeout=5s  Timeout for trying to get stats from JFrog Artifactory.
       --access-federation-target=ACCESS-FEDERATION-TARGET
@@ -156,6 +158,7 @@ Flags:
 | `web.listen-address`<br/>`WEB_LISTEN_ADDR`     | No       | `:9531`                             | Address to listen on for web interface and telemetry.                                                                                                                                    |
 | `web.telemetry-path`<br/>`WEB_TELEMETRY_PATH`  | No       | `/metrics`                          | Path under which to expose metrics.                                                                                                                                                      |
 | `artifactory.scrape-uri`<br/>`ARTI_SCRAPE_URI` | No       | `http://localhost:8081/artifactory` | URI on which to scrape JFrog Artifactory.                                                                                                                                                |
+| `xray.scrape-uri`<br/>`XRAY_SCRAPE_URI` | No | `http://localhost:8081/xray` | URI on which to scrape JFrog Artifactory.                                                                                                                                                                    |
 | `artifactory.ssl-verify`<br/>`ARTI_SSL_VERIFY` | No       | `true`                              | Flag that enables SSL certificate verification for the scrape URI.                                                                                                                       |
 | `artifactory.timeout`<br/>`ARTI_TIMEOUT`       | No       | `5s`                                | Timeout for trying to get stats from JFrog Artifactory.                                                                                                                                  |
 | `use-cache`<br/>`USE_CACHE`                    | No       | `false`                             | Use caching for API responses to circumvent timeouts.                                                                                                                                    |
@@ -222,6 +225,7 @@ Supported optional metrics:
 * `replication_status` - Extracts status of replication for each repository which has replication enabled. Enabling this will add the `status` label to `artifactory_replication_enabled` metric.
 * `federation_status` - Extracts federation metrics. Enabling this will add two new metrics: `artifactory_federation_mirror_lag`, and `artifactory_federation_unavailable_mirror`. Please note that these metrics are only available in Artifactory Enterprise Plus and version 7.18.3 and above.
 * `open_metrics` - Exposes Open Metrics from the JFrog Platform. For more information about Open Metrics, please refer to [JFrog Platform Open Metrics](https://jfrog.com/help/r/jfrog-platform-administration-documentation/open-metrics).
+* `xray` - Exposes Open Metrics from Xray. For more information about Open Metrics, please refer to [JFrog Platform Open Metrics](https://jfrog.com/help/r/jfrog-platform-administration-documentation/open-metrics).
 * `access_federation_validate` - Validates whether trust is established towards a given JFrog Access Federation target server. Requires optional parameter `access-federation-target` to be set to the URL of the target server as well as token-based authentication. For more information, please refer to [JFrog Access Federation Circle of Trust validation](https://jfrog.com/help/r/jfrog-rest-apis/validate-target-for-circle-of-trust).
 * `background_tasks` - Tracks the number of Artifactory background tasks by type and state. Enabling this will add the `artifactory_background_tasks` metric. Use this to monitor scheduled, running, stopped, or canceled tasks.
 

--- a/artifactory/client.go
+++ b/artifactory/client.go
@@ -23,6 +23,7 @@ type Client struct {
 	client                 *http.Client
 	logger                 *slog.Logger
 	responseCache          *ResponseCache
+	XrayURI                string
 }
 
 // NewClient returns an initialized Artifactory HTTP Client.
@@ -52,6 +53,7 @@ func NewClient(conf *config.Config) *Client {
 		client:                 client,
 		logger:                 logger,
 		responseCache:          responseCache,
+		XrayURI:                conf.XrayScrapeURI,
 	}
 }
 

--- a/artifactory/openmetrics.go
+++ b/artifactory/openmetrics.go
@@ -29,3 +29,30 @@ func (c *Client) FetchOpenMetrics() (OpenMetrics, error) {
 
 	return openMetrics, nil
 }
+
+// FetchXrayOpenMetrics makes the API call to open metrics endpoint and returns all the open metrics
+func (c *Client) FetchXrayOpenMetrics() (OpenMetrics, error) {
+	var openMetrics OpenMetrics
+	c.logger.Debug("Fetching openMetrics")
+	// Temporarily override the URI to use Xray
+	originalURI := c.URI
+	c.URI = c.XrayURI
+	defer func() { c.URI = originalURI }()
+	resp, err := c.FetchHTTP(openMetricsEndpoint)
+	if err != nil {
+		if err.(*APIError).status == 404 {
+			return openMetrics, nil
+		}
+		return openMetrics, err
+	}
+
+	c.logger.Debug(
+		"OpenMetrics from Xray",
+		"body", string(resp.Body),
+	)
+
+	openMetrics.NodeId = resp.NodeId
+	openMetrics.PromMetrics = string(resp.Body)
+
+	return openMetrics, nil
+}

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -209,6 +209,14 @@ func (e *Exporter) runExportSteps(ch chan<- prometheus.Metric) bool {
 		e.exportArtifacts(repoSummaryList, ch)
 	}
 
+	if e.exporterRuntimeConfig.OptionalMetrics.Xray {
+		err = e.exportXrayOpenMetrics(ch)
+		if err != nil {
+			return false
+		}
+
+	}
+
 	if e.exporterRuntimeConfig.OptionalMetrics.FederationStatus && e.client.IsFederationEnabled() {
 		e.exportFederationMirrorLags(ch)
 		e.exportFederationUnavailableMirrors(ch)

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -216,7 +216,6 @@ func (e *Exporter) runExportSteps(ch chan<- prometheus.Metric) bool {
 		}
 
 	}
-
 	if e.exporterRuntimeConfig.OptionalMetrics.FederationStatus && e.client.IsFederationEnabled() {
 		e.exportFederationMirrorLags(ch)
 		e.exportFederationUnavailableMirrors(ch)

--- a/collector/openMetrics.go
+++ b/collector/openMetrics.go
@@ -1,12 +1,7 @@
 package collector
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/prometheus/client_golang/prometheus"
-	ioPrometheusClient "github.com/prometheus/client_model/go"
-	"github.com/prometheus/common/expfmt"
 )
 
 func (e *Exporter) exportOpenMetrics(ch chan<- prometheus.Metric) error {
@@ -17,71 +12,16 @@ func (e *Exporter) exportOpenMetrics(ch chan<- prometheus.Metric) error {
 		return err
 	}
 
-	openMetricsString := sanitizeOpenMetrics(openMetrics.PromMetrics)
-	e.logger.Debug(
-		"OpenMetrics from Artifactory util",
-		"body", openMetricsString,
-	)
-	parser := expfmt.TextParser{}
-	metrics, err := parser.TextToMetricFamilies(strings.NewReader(openMetricsString))
-	if err != nil {
-		e.logger.Error(
-			"Openmetrics downloaded from artifactory cannot be parsed using the “github.com/prometheus/common/expfmt”.",
-			"err", err.Error(),
-			"response.body", openMetricsString,
-		)
-		return fmt.Errorf(
-			"problem when parsing openmetrics downloaded from artifactory: %w",
-			err,
-		)
-	}
-
-	createDesc := func(fn, fh string, m *ioPrometheusClient.Metric) *prometheus.Desc {
-		labels := make(map[string]string)
-		for _, label := range m.Label {
-			labels[*label.Name] = *label.Value
-		}
-		return prometheus.NewDesc(fn, fh, nil, labels)
-	}
-	for _, family := range metrics {
-		fName := family.GetName()
-		fHelp := family.GetHelp()
-		for _, metric := range family.Metric {
-			desc := createDesc(fName, fHelp, metric)
-			switch family.GetType() {
-			case ioPrometheusClient.MetricType_COUNTER:
-				ch <- prometheus.MustNewConstMetric(
-					desc,
-					prometheus.CounterValue,
-					metric.GetCounter().GetValue(),
-				)
-			case ioPrometheusClient.MetricType_GAUGE:
-				ch <- prometheus.MustNewConstMetric(
-					desc,
-					prometheus.GaugeValue,
-					metric.GetGauge().GetValue(),
-				)
-			}
-		}
-	}
-
-	return nil
+	return e.processOpenMetrics(openMetrics, ch, "artifactory")
 }
 
-// sanitizeOpenMetrics sanitizes the OpenMetrics string
-func sanitizeOpenMetrics(input string) string {
-	lines := strings.Split(input, "\n")
-	var result []string
-
-	for _, line := range lines {
-		if strings.HasPrefix(line, "# HELP") || strings.HasPrefix(line, "# TYPE") {
-			line = strings.ReplaceAll(line, `\"`, `"`)
-		}
-		if strings.HasPrefix(line, "# EOF") {
-			continue
-		}
-		result = append(result, line)
+func (e *Exporter) exportXrayOpenMetrics(ch chan<- prometheus.Metric) error {
+	openMetrics, err := e.client.FetchXrayOpenMetrics()
+	if err != nil {
+		e.logger.Error("There was an issue when try to fetch openMetrics")
+		e.totalAPIErrors.Inc()
+		return err
 	}
 
-	return strings.Join(result, "\n")
+	return e.processOpenMetrics(openMetrics, ch, "xray")
 }

--- a/collector/openMetricsHelper.go
+++ b/collector/openMetricsHelper.go
@@ -41,12 +41,12 @@ func (e *Exporter) processOpenMetrics(openMetrics artifactory.OpenMetrics, ch ch
 	metrics, err := parser.TextToMetricFamilies(strings.NewReader(openMetricsString))
 	if err != nil {
 		e.logger.Error(
-			fmt.Sprintf("Openmetrics downloaded from %s cannot be parsed using the \"github.com/prometheus/common/expfmt\".", source),
+			fmt.Sprintf("OpenMetrics downloaded from %s cannot be parsed using the \"github.com/prometheus/common/expfmt\".", source),
 			"err", err.Error(),
 			"response.body", openMetricsString,
 		)
 		return fmt.Errorf(
-			"problem when parsing openmetrics downloaded from %s: %w",
+			"problem when parsing OpenMetrics downloaded from %s: %w",
 			source, err,
 		)
 	}
@@ -62,7 +62,7 @@ func (e *Exporter) processOpenMetrics(openMetrics artifactory.OpenMetrics, ch ch
 	for _, family := range metrics {
 		fName := family.GetName()
 		fHelp := family.GetHelp()
-		if strings.HasPrefix(fName, "process_") { // avoid conflict with promethues internal metrics
+		if strings.HasPrefix(fName, "process_") { // avoid conflict with prometheus internal metrics
 			fName = source + fName
 		}
 		for _, metric := range family.Metric {

--- a/collector/openMetricsHelper.go
+++ b/collector/openMetricsHelper.go
@@ -1,0 +1,88 @@
+package collector
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/peimanja/artifactory_exporter/artifactory"
+	"github.com/prometheus/client_golang/prometheus"
+	ioPrometheusClient "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+// sanitizeOpenMetrics sanitizes the OpenMetrics string
+func sanitizeOpenMetrics(input string) string {
+	lines := strings.Split(input, "\n")
+	var result []string
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "# HELP") || strings.HasPrefix(line, "# TYPE") {
+			line = strings.ReplaceAll(line, `\"`, `"`)
+		}
+		if strings.HasPrefix(line, "# EOF") {
+			continue
+		}
+		result = append(result, line)
+	}
+
+	return strings.Join(result, "\n")
+}
+
+// processOpenMetrics is a modular helper function that processes OpenMetrics data
+// and exports it to the prometheus metrics channel
+func (e *Exporter) processOpenMetrics(openMetrics artifactory.OpenMetrics, ch chan<- prometheus.Metric, source string) error {
+	openMetricsString := sanitizeOpenMetrics(openMetrics.PromMetrics)
+	e.logger.Debug(
+		fmt.Sprintf("OpenMetrics from %s", source),
+		"body", openMetricsString,
+	)
+
+	parser := expfmt.TextParser{}
+	metrics, err := parser.TextToMetricFamilies(strings.NewReader(openMetricsString))
+	if err != nil {
+		e.logger.Error(
+			fmt.Sprintf("Openmetrics downloaded from %s cannot be parsed using the \"github.com/prometheus/common/expfmt\".", source),
+			"err", err.Error(),
+			"response.body", openMetricsString,
+		)
+		return fmt.Errorf(
+			"problem when parsing openmetrics downloaded from %s: %w",
+			source, err,
+		)
+	}
+
+	createDesc := func(fn, fh string, m *ioPrometheusClient.Metric) *prometheus.Desc {
+		labels := make(map[string]string)
+		for _, label := range m.Label {
+			labels[*label.Name] = *label.Value
+		}
+		return prometheus.NewDesc(fn, fh, nil, labels)
+	}
+
+	for _, family := range metrics {
+		fName := family.GetName()
+		fHelp := family.GetHelp()
+		if strings.HasPrefix(fName, "process_") { // avoid conflict with promethues internal metrics
+			fName = source + fName
+		}
+		for _, metric := range family.Metric {
+			desc := createDesc(fName, fHelp, metric)
+			switch family.GetType() {
+			case ioPrometheusClient.MetricType_COUNTER:
+				ch <- prometheus.MustNewConstMetric(
+					desc,
+					prometheus.CounterValue,
+					metric.GetCounter().GetValue(),
+				)
+			case ioPrometheusClient.MetricType_GAUGE:
+				ch <- prometheus.MustNewConstMetric(
+					desc,
+					prometheus.GaugeValue,
+					metric.GetGauge().GetValue(),
+				)
+			}
+		}
+	}
+
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -172,7 +172,7 @@ func NewConfig() (*Config, error) {
 			return nil, err
 		}
 	} else if optMetrics.Xray {
-		return nil, fmt.Errorf("Jfrog Xray scrape URI must be set if optional metric Xray is enabled")
+		return nil, fmt.Errorf("JFrog Xray scrape URI must be set if optional metric Xray is enabled")
 	}
 
 	logger := l.New(

--- a/config/config.go
+++ b/config/config.go
@@ -7,10 +7,9 @@ import (
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
+	l "github.com/peimanja/artifactory_exporter/logger"
 	"github.com/prometheus/common/version"
 	"gopkg.in/alecthomas/kingpin.v2"
-
-	l "github.com/peimanja/artifactory_exporter/logger"
 )
 
 var (
@@ -19,6 +18,7 @@ var (
 	listenAddress          = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Envar("WEB_LISTEN_ADDR").Default(":9531").String()
 	metricsPath            = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Envar("WEB_TELEMETRY_PATH").Default("/metrics").String()
 	artiScrapeURI          = kingpin.Flag("artifactory.scrape-uri", "URI on which to scrape JFrog Artifactory.").Envar("ARTI_SCRAPE_URI").Default("http://localhost:8081/artifactory").String()
+	xrayScrapeURI          = kingpin.Flag("xray.scrape-uri", "URI on which to scrape JFrog Xray.").Envar("XRAY_SCRAPE_URI").Default("http://localhost:8081/xray").String()
 	artiSSLVerify          = kingpin.Flag("artifactory.ssl-verify", "Flag that enables SSL certificate verification for the scrape URI").Envar("ARTI_SSL_VERIFY").Default("false").Bool()
 	artiTimeout            = kingpin.Flag("artifactory.timeout", "Timeout for trying to get stats from JFrog Artifactory.").Envar("ARTI_TIMEOUT").Default("5s").Duration()
 	optionalMetrics        = kingpin.Flag("optional-metric", fmt.Sprintf("optional metric to be enabled. Valid metrics are: %v", optionalMetricsList)).PlaceHolder("metric-name").Strings()
@@ -29,7 +29,7 @@ var (
 	artifactsTimeIntervals = kingpin.Flag("artifacts-time-interval", "Time interval for created and downloaded stats").Default("1m", "5m", "15m").DurationList()
 )
 
-var optionalMetricsList = []string{"artifacts", "replication_status", "federation_status", "open_metrics", "access_federation_validate", "background_tasks"}
+var optionalMetricsList = []string{"artifacts", "replication_status", "federation_status", "open_metrics", "access_federation_validate", "background_tasks", "xray"}
 
 // Credentials represents Username and Password or API Key for
 // Artifactory Authentication
@@ -48,6 +48,7 @@ type OptionalMetrics struct {
 	OpenMetrics              bool `yaml:"open_metrics"`
 	AccessFederationValidate bool `yaml:"access_federation_validate"`
 	BackgroundTasks          bool `yaml:"background_tasks"`
+	Xray                     bool `yaml:"xray"`
 }
 
 type timeInterval struct {
@@ -76,6 +77,7 @@ type Config struct {
 	ExporterRuntimeConfig  *ExporterRuntimeConfig
 	AccessFederationTarget string
 	Logger                 *slog.Logger
+	XrayScrapeURI          string
 }
 
 func getAqlTimeFormat(d time.Duration) (int, string) {
@@ -132,6 +134,8 @@ func NewConfig() (*Config, error) {
 			optMetrics.AccessFederationValidate = true
 		case "background_tasks":
 			optMetrics.BackgroundTasks = true
+		case "xray":
+			optMetrics.Xray = true
 		default:
 			return nil, fmt.Errorf("unknown optional metric: %s. Valid optional metrics are: %v", metric, optionalMetricsList)
 		}
@@ -160,6 +164,15 @@ func NewConfig() (*Config, error) {
 		}
 	} else if optMetrics.AccessFederationValidate {
 		return nil, fmt.Errorf("JFrog Access Federation target URL must be set if optional metric AccessFederationValidate is enabled")
+	}
+
+	if *xrayScrapeURI != "" {
+		_, err = url.Parse(*xrayScrapeURI)
+		if err != nil {
+			return nil, err
+		}
+	} else if optMetrics.Xray {
+		return nil, fmt.Errorf("Jfrog Xray scrape URI must be set if optional metric Xray is enabled")
 	}
 
 	logger := l.New(

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -369,6 +369,7 @@ func TestOptionalMetricsList(t *testing.T) {
 		"open_metrics",
 		"access_federation_validate",
 		"background_tasks",
+		"xray",
 	}
 
 	if len(optionalMetricsList) != len(expectedMetrics) {


### PR DESCRIPTION
Adds JFrog Xray OpenMetrics collection while refactoring existing OpenMetrics code for better reusability.

- Modular OpenMetrics processing: Extracted shared logic into processOpenMetrics() helper function
- New Xray support: Added --xray.scrape-uri flag and xray optional metric
- Metric collision prevention: Added prefixing for process_* metrics