### PR TITLE
Collector continues with other exports if single step fails

### DIFF
--- a/artifactory/license_test.go
+++ b/artifactory/license_test.go
@@ -120,13 +120,13 @@ func TestLicenseInfo_ValidSeconds(t *testing.T) {
 		},
 		{
 			name:        "Valid date format",
-			license:     LicenseInfo{Type: "Enterprise", ValidThrough: "Dec 31, 2025"},
+			license:     LicenseInfo{Type: "Enterprise", ValidThrough: "Dec 31, 2027"},
 			wantErr:     false,
 			description: "Standard date format should parse correctly",
 		},
 		{
 			name:        "Edge license with XX day",
-			license:     LicenseInfo{Type: "Edge", ValidThrough: "Dec XX, 2025"},
+			license:     LicenseInfo{Type: "Edge", ValidThrough: "Dec XX, 2027"},
 			wantErr:     false,
 			description: "Edge licenses with XX day should default to 1st of month",
 		},
@@ -192,7 +192,7 @@ func TestLicenseInfo_ValidSeconds_EdgeCaseHandling(t *testing.T) {
 	// Test the specific case from the bug report
 	license := LicenseInfo{
 		Type:         "Edge",
-		ValidThrough: "Dec XX, 2025", // Use December instead of July since we're in August 2025
+		ValidThrough: "Dec XX, 2027", // Use December instead of July since we're in August 2025
 		LicensedTo:   "Test Company",
 	}
 
@@ -201,13 +201,13 @@ func TestLicenseInfo_ValidSeconds_EdgeCaseHandling(t *testing.T) {
 		t.Errorf("ValidSeconds() for Edge license with XX day failed: %v", err)
 	}
 
-	// The function should have normalized "Dec XX, 2025" to "Dec 1, 2025"
-	// and calculated seconds from current time to December 1, 2025
+	// The function should have normalized "Dec XX, 2027" to "Dec 1, 2027"
+	// and calculated seconds from current time to December 1, 2027
 	if seconds <= 0 {
 		t.Errorf("ValidSeconds() returned non-positive value %d, expected positive future date", seconds)
 	}
 
-	t.Logf("Edge license with 'Dec XX, 2025' correctly parsed, returning %d seconds", seconds)
+	t.Logf("Edge license with 'Dec XX, 2027' correctly parsed, returning %d seconds", seconds)
 }
 
 func TestLicenseInfo_ValidSeconds_DateNormalization(t *testing.T) {
@@ -218,13 +218,13 @@ func TestLicenseInfo_ValidSeconds_DateNormalization(t *testing.T) {
 	}{
 		{
 			name:     "XX in day position",
-			input:    "Dec XX, 2025",
-			expected: "normalized to Dec 1, 2025",
+			input:    "Dec XX, 2027",
+			expected: "normalized to Dec 1, 2027",
 		},
 		{
 			name:     "Regular numeric day",
-			input:    "Dec 15, 2025",
-			expected: "remains Dec 15, 2025",
+			input:    "Dec 15, 2027",
+			expected: "remains Dec 15, 2027",
 		},
 		{
 			name:     "Single digit day",

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -201,26 +201,26 @@ func (e *Exporter) runExportSteps(ch chan<- prometheus.Metric) bool {
 		e.totalAPIErrors.Inc()
 		e.logger.Error("Failed to fetch storage info", "err", err)
 	} else {
+		e.exportStorage(storageInfo, ch)
 		anySuccess = true
 	}
-	e.exportStorage(storageInfo, ch)
 
 	repoSummaryList, err := e.extractRepo(storageInfo)
 	if err != nil {
 		e.logger.Error("Failed to extract repo summary", "err", err)
 	} else {
+		e.exportRepo(repoSummaryList, ch)
 		anySuccess = true
 	}
-	e.exportRepo(repoSummaryList, ch)
 
 	if e.exporterRuntimeConfig.OptionalMetrics.Artifacts {
 		repoSummaryList, err = e.getTotalArtifacts(repoSummaryList)
 		if err != nil {
 			e.logger.Error("Failed to get total artifacts", "err", err)
 		} else {
+			e.exportArtifacts(repoSummaryList, ch)
 			anySuccess = true
 		}
-		e.exportArtifacts(repoSummaryList, ch)
 	}
 
 	if e.exporterRuntimeConfig.OptionalMetrics.FederationStatus && e.client.IsFederationEnabled() {

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -226,12 +226,10 @@ func (e *Exporter) runExportSteps(ch chan<- prometheus.Metric) bool {
 	if e.exporterRuntimeConfig.OptionalMetrics.FederationStatus && e.client.IsFederationEnabled() {
 		e.exportFederationMirrorLags(ch)
 		e.exportFederationUnavailableMirrors(ch)
-		anySuccess = true
 	}
 
 	if e.exporterRuntimeConfig.OptionalMetrics.AccessFederationValidate {
 		e.exportAccessFederationValidate(ch)
-		anySuccess = true
 	}
 
 	return anySuccess

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -174,37 +174,51 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) float64 {
 }
 
 // runExportSteps performs the main metric collection sequence.
-// Returns false if any required step fails.
+// Continues collecting metrics even if individual step fails.
 func (e *Exporter) runExportSteps(ch chan<- prometheus.Metric) bool {
+	anySuccess := false
+
 	if e.exporterRuntimeConfig.OptionalMetrics.OpenMetrics {
 		if err := e.exportOpenMetrics(ch); err != nil {
-			return false
+			e.logger.Error("Failed to export open metrics", "err", err)
+		} else {
+			anySuccess = true
 		}
 	}
 	if err := e.exportSystem(ch); err != nil {
-		return false
+		e.logger.Error("Failed to export system metrics", "err", err)
+	} else {
+		anySuccess = true
 	}
 	if err := e.exportSystemHALicenses(ch); err != nil {
-		return false
+		e.logger.Error("Failed to export HA licenses", "err", err)
+	} else {
+		anySuccess = true
 	}
 
 	storageInfo, err := e.client.FetchStorageInfo()
 	if err != nil {
 		e.totalAPIErrors.Inc()
-		return false
+		e.logger.Error("Failed to fetch storage info", "err", err)
+	} else {
+		anySuccess = true
 	}
 	e.exportStorage(storageInfo, ch)
 
 	repoSummaryList, err := e.extractRepo(storageInfo)
 	if err != nil {
-		return false
+		e.logger.Error("Failed to extract repo summary", "err", err)
+	} else {
+		anySuccess = true
 	}
 	e.exportRepo(repoSummaryList, ch)
 
 	if e.exporterRuntimeConfig.OptionalMetrics.Artifacts {
 		repoSummaryList, err = e.getTotalArtifacts(repoSummaryList)
 		if err != nil {
-			return false
+			e.logger.Error("Failed to get total artifacts", "err", err)
+		} else {
+			anySuccess = true
 		}
 		e.exportArtifacts(repoSummaryList, ch)
 	}
@@ -212,13 +226,15 @@ func (e *Exporter) runExportSteps(ch chan<- prometheus.Metric) bool {
 	if e.exporterRuntimeConfig.OptionalMetrics.FederationStatus && e.client.IsFederationEnabled() {
 		e.exportFederationMirrorLags(ch)
 		e.exportFederationUnavailableMirrors(ch)
+		anySuccess = true
 	}
 
 	if e.exporterRuntimeConfig.OptionalMetrics.AccessFederationValidate {
 		e.exportAccessFederationValidate(ch)
+		anySuccess = true
 	}
 
-	return true
+	return anySuccess
 }
 
 // collectBackgroundTasks emits a count of background tasks by (type, state) combination.


### PR DESCRIPTION
Hello there!

This is my first contribution to this project 👋🏻 

Changes are related to collector logic and updating test suite.

### Improve collector resilience on export failures

I updated the collector logic so that a failure in one export does not stop other metrics from being exported. This was noticed while debugging scenarios similar to #171 : when the license endpoint failed, other metrics (e.g. artifacts) were not exported even though they were available. With this change, the collector logs individual failures and continues exporting remaining metrics even if one export fails. 

I'm happy to discuss & adjust if it is preferable to introduce more optional metrics for the licenses instead of changing the collector logic.

### Fix failing license tests

The license related tests were failing due to an expired license (2025).
I’ve updated the tests to reflect the current valid license period so they pass again.

Please let me know if you’d like this split into separate PRs or adjusted in any way. 

Thanks for maintaining the project!